### PR TITLE
Add option to dump results as JUnit XML

### DIFF
--- a/Criterion/Config.hs
+++ b/Criterion/Config.hs
@@ -56,6 +56,7 @@ data Config = Config {
     , cfgCompareFile  :: Last FilePath -- ^ Filename of the comparison CSV.
     , cfgTemplate     :: Last FilePath -- ^ Filename of report template.
     , cfgVerbosity    :: Last Verbosity -- ^ Whether to run verbosely.
+    , cfgJUnitFile    :: Last FilePath -- ^ Filename of JUnit report.
     } deriving (Eq, Read, Show, Typeable)
 
 instance Monoid Config where
@@ -76,6 +77,7 @@ defaultConfig = Config {
                 , cfgCompareFile  = mempty
                 , cfgTemplate     = ljust "report.tpl"
                 , cfgVerbosity    = ljust Normal
+                , cfgJUnitFile    = mempty
                 }
 
 -- | Constructor for 'Last' values.
@@ -103,6 +105,7 @@ emptyConfig = Config {
               , cfgCompareFile  = mempty
               , cfgTemplate     = mempty
               , cfgVerbosity    = mempty
+              , cfgJUnitFile    = mempty
               }
 
 appendConfig :: Config -> Config -> Config
@@ -119,5 +122,6 @@ appendConfig a b =
     , cfgCompareFile  = app cfgCompareFile a b
     , cfgTemplate     = app cfgTemplate a b
     , cfgVerbosity    = app cfgVerbosity a b
+    , cfgJUnitFile    = app cfgJUnitFile a b
     }
   where app f = mappend `on` f

--- a/Criterion/Main.hs
+++ b/Criterion/Main.hs
@@ -118,6 +118,8 @@ defaultOptions = [
           "display version, then exit"
  , Option ['v'] ["verbose"] (noArg mempty { cfgVerbosity = ljust Verbose })
           "print more output"
+ , Option [] ["junit"] (ReqArg (\s -> return $ mempty { cfgJUnitFile = ljust s }) "FILENAME")
+          "produce a JUnit report file of all results"
  ]
 
 printBanner :: Config -> IO ()


### PR DESCRIPTION
By dumping the results as JUnit XML we can plot them over time using e.g. the Jenkins Performance plugin.
