### PR TITLE
Remove superfluous and misleading import of Criterion.MultiMap in the example of defaultMainWithSource

### DIFF
--- a/Criterion/Main.hs
+++ b/Criterion/Main.hs
@@ -175,7 +175,6 @@ defaultMain = defaultMainWith defaultConfig (return ())
 -- Example:
 --
 -- > import Criterion.Config
--- > import qualified Criterion.MultiMap as M
 -- > import Criterion.Main
 -- >
 -- > myConfig = defaultConfig {


### PR DESCRIPTION
The example in the documentation for Criterion.Main.defaultMainWithSource is
invalid due to an import of Criterion.MultiMap which was removed in #4224289a
and isn't necessary for the given example anymore.
