### PR TITLE
Fixed to build against `cassava-0.3.0.0`.  Fixes #34

### DIFF
--- a/Criterion/IO/Printf.hs
+++ b/Criterion/IO/Printf.hs
@@ -29,7 +29,6 @@ import System.IO (Handle, stderr, stdout)
 import Text.Printf (PrintfArg)
 import qualified Data.ByteString.Lazy as B
 import qualified Data.Csv as Csv
-import qualified Data.Vector.Generic as G
 import qualified Text.Printf (HPrintfType, hPrintf)
 
 -- First item is the action to print now, given all the arguments
@@ -99,5 +98,5 @@ writeCsv :: Csv.ToRecord a => a -> Criterion ()
 writeCsv val = do
   sumOpt <- getConfigItem (getLast . cfgSummaryFile)
   case sumOpt of
-    Just fn -> liftIO . B.appendFile fn . Csv.encode . G.singleton $ val
+    Just fn -> liftIO . B.appendFile fn . Csv.encode $ [val]
     Nothing -> return ()

--- a/criterion.cabal
+++ b/criterion.cabal
@@ -69,7 +69,7 @@ library
     base < 5,
     binary >= 0.6.3.0,
     bytestring >= 0.9 && < 1.0,
-    cassava,
+    cassava >= 0.3.0.0,
     containers,
     deepseq >= 1.1.0.0,
     directory,


### PR DESCRIPTION
`cassava-0.3.0.0` changed `encode` to accept a list instead of a vector.  This
patch changes `Criterion.IO.Printf` to use the new `encode`, and also sets
a lower bound of `cassava-0.3.0.0`.
