### PR TITLE
fixed dependency on optparse-applicative

### DIFF
--- a/criterion.cabal
+++ b/criterion.cabal
@@ -86,7 +86,7 @@ library
     hastache >= 0.6.0,
     mtl >= 2,
     mwc-random >= 0.8.0.3,
-    optparse-applicative,
+    optparse-applicative < 0.10,
     parsec >= 3.1.0,
     statistics >= 0.13.2.1,
     text >= 0.11,


### PR DESCRIPTION
A recent release of optparse-applicative had breaking changes to the interface, so criterion now fails to compile in a clean sandbox.  This version upper bound fixes the issue.
