### PR TITLE
preserve existing 'regressions' options when parsing command line opts

### DIFF
--- a/Criterion/Main/Options.hs
+++ b/Criterion/Main/Options.hs
@@ -111,9 +111,9 @@ config Config{..} = Config
   <*> option (range 1 1000000)
       (long "resamples" <> metavar "COUNT" <> value resamples <>
        help "number of bootstrap resamples to perform")
-  <*> many (option regressParams
-            (long "regress" <> metavar "RESP:PRED.." <>
-             help "regressions to perform"))
+  <*> ((regressions ++) <$> many (option regressParams
+                                 (long "regress" <> metavar "RESP:PRED.." <>
+                                  help "regressions to perform")))
   <*> outputOption rawDataFile (long "raw" <>
                                 help "file to write raw data to")
   <*> outputOption reportFile (long "output" <> short 'o' <>


### PR DESCRIPTION
When using 'defaultMainWith', the existing command line parser would discard the existing values for 'Config.regressions' and replace it with only the new "--regress=..." entries it parses. This change preserves the old values as well.