### PR TITLE
add `--match pattern` and `--match ipattern` matchers

### DIFF
--- a/Criterion/Main.hs
+++ b/Criterion/Main.hs
@@ -53,7 +53,8 @@ import Criterion.Main.Options (MatchType(..), Mode(..), defaultConfig, describe,
 import Criterion.Measurement (initializeTime)
 import Criterion.Monad (withConfig)
 import Criterion.Types
-import Data.List (isPrefixOf, sort, stripPrefix)
+import Data.Char (toLower)
+import Data.List (isInfixOf, isPrefixOf, sort, stripPrefix)
 import Data.Maybe (fromMaybe)
 import Options.Applicative (execParser)
 import System.Environment (getProgName)
@@ -93,6 +94,8 @@ makeMatcher matchKind args =
            Left errMsg -> Left . fromMaybe errMsg . stripPrefix "compile :: " $
                           errMsg
            Right ps -> Right $ \b -> null ps || any (`match` b) ps
+    Pattern -> Right $ \b -> null args || any (`isInfixOf` b) args
+    IPattern -> Right $ \b -> null args || any (`isInfixOf` map toLower b) (map (map toLower) args)
 
 selectBenches :: MatchType -> [String] -> Benchmark -> IO (String -> Bool)
 selectBenches matchType benches bsgroup = do

--- a/Criterion/Main/Options.hs
+++ b/Criterion/Main/Options.hs
@@ -46,6 +46,11 @@ data MatchType = Prefix
                  -- @\"foo\"@ will match @\"foobar\"@.
                | Glob
                  -- ^ Match by Unix-style glob pattern.
+               | Pattern
+                 -- ^ Match by searching given substring in benchmark
+                 -- paths.
+               | IPattern
+                 -- ^ Same as 'Pattern', but case insensitive.
                deriving (Eq, Ord, Bounded, Enum, Read, Show, Typeable, Data,
                          Generic)
 
@@ -148,11 +153,13 @@ match :: ReadM MatchType
 match = do
   m <- readerAsk
   case map toLower m of
-    mm | mm `isPrefixOf` "pfx"    -> return Prefix
-       | mm `isPrefixOf` "prefix" -> return Prefix
-       | mm `isPrefixOf` "glob"   -> return Glob
-       | otherwise                -> readerError $
-                                     show m ++ " is not a known match type"
+    mm | mm `isPrefixOf` "pfx"      -> return Prefix
+       | mm `isPrefixOf` "prefix"   -> return Prefix
+       | mm `isPrefixOf` "glob"     -> return Glob
+       | mm `isPrefixOf` "pattern"  -> return Pattern
+       | mm `isPrefixOf` "ipattern" -> return IPattern
+       | otherwise                  -> readerError $
+                                       show m ++ " is not a known match type"
 
 regressParams :: ReadM ([String], String)
 regressParams = do


### PR DESCRIPTION
Interestingly, I found prefix matcher completely useless and glob matcher hard to use(can that even handle case insensitivity? I don't think so).

I guess most general solution would be to provide a regex matcher, but to keep it simple I wanted to go with these simple solutions.