### PR TITLE
New feature: algorithm comparison graphs

### DIFF
--- a/Criterion.hs
+++ b/Criterion.hs
@@ -59,4 +59,4 @@ benchmarkWith' cfg bm = do
   initializeTime
   withConfig cfg $ do
     _ <- note "benchmarking...\n"
-    runAndAnalyseOne 0 (ROBench "function") bm
+    runAndAnalyseOne 0 [ROBench "function"] bm

--- a/Criterion.hs
+++ b/Criterion.hs
@@ -19,6 +19,7 @@ module Criterion
     , env
     , bench
     , bgroup
+    , bversus
     -- ** Running a benchmark
     , nf
     , whnf

--- a/Criterion.hs
+++ b/Criterion.hs
@@ -59,4 +59,4 @@ benchmarkWith' cfg bm = do
   initializeTime
   withConfig cfg $ do
     _ <- note "benchmarking...\n"
-    runAndAnalyseOne 0 "function" bm
+    runAndAnalyseOne 0 (ROBench "function") bm

--- a/Criterion.hs
+++ b/Criterion.hs
@@ -59,4 +59,4 @@ benchmarkWith' cfg bm = do
   initializeTime
   withConfig cfg $ do
     _ <- note "benchmarking...\n"
-    runAndAnalyseOne 0 [ROBench "function"] bm
+    runAndAnalyseOne 0 "function" bm

--- a/Criterion/Analysis.hs
+++ b/Criterion/Analysis.hs
@@ -132,10 +132,11 @@ scale f s@SampleAnalysis{..} = s {
 
 -- | Perform an analysis of a measurement.
 analyseSample :: Int            -- ^ Experiment number.
-              -> String         -- ^ Experiment name.
+              -> ReportOwner    -- ^ Experiment name.
               -> V.Vector Measured -- ^ Sample data.
               -> EitherT String Criterion Report
-analyseSample i name meas = do
+analyseSample i ro meas = do
+  let name = reportOwnerToName ro
   Config{..} <- ask
   overhead <- lift getOverhead
   let ests      = [Mean,StdDev]
@@ -172,6 +173,7 @@ analyseSample i name meas = do
     , reportAnalysis = an
     , reportOutliers = classifyOutliers stime
     , reportKDEs     = [uncurry (KDE "time") (kde 128 stime)]
+    , reportOwner    = ro
     }
 
 -- | Regress the given predictors against the responder.

--- a/Criterion/Analysis.hs
+++ b/Criterion/Analysis.hs
@@ -132,11 +132,10 @@ scale f s@SampleAnalysis{..} = s {
 
 -- | Perform an analysis of a measurement.
 analyseSample :: Int            -- ^ Experiment number.
-              -> ReportOwner    -- ^ Experiment name.
+              -> String         -- ^ Experiment name.
               -> V.Vector Measured -- ^ Sample data.
               -> EitherT String Criterion Report
-analyseSample i ro meas = do
-  let name = reportOwnerToName ro
+analyseSample i name meas = do
   Config{..} <- ask
   overhead <- lift getOverhead
   let ests      = [Mean,StdDev]
@@ -173,7 +172,6 @@ analyseSample i ro meas = do
     , reportAnalysis = an
     , reportOutliers = classifyOutliers stime
     , reportKDEs     = [uncurry (KDE "time") (kde 128 stime)]
-    , reportOwner    = ro
     }
 
 -- | Regress the given predictors against the responder.

--- a/Criterion/IO/Printf.hs
+++ b/Criterion/IO/Printf.hs
@@ -94,8 +94,7 @@ printError :: (CritHPrintfType r) => String -> r
 printError = chPrintf (const True) stderr
 
 -- | Write a record to a CSV file.
-writeCsv :: Csv.ToRecord a => a -> Criterion ()
-writeCsv val = do
-  csv <- asks csvFile
-  forM_ csv $ \fn ->
+writeCsv :: Csv.ToRecord a => Maybe FilePath -> a -> Criterion ()
+writeCsv file val = 
+  forM_ file $ \fn ->
     liftIO . B.appendFile fn . Csv.encode $ [val]

--- a/Criterion/Internal.hs
+++ b/Criterion/Internal.hs
@@ -74,10 +74,10 @@ runAndAnalyseOne i ro bm = do
         _ <- bs r2 (regResponder ++ ":") regRSquare
         forM_ (Map.toList regCoeffs) $ \(prd,val) ->
           bs (printf "%.3g") ("  " ++ prd) val
-      writeCsv (desc,
-                estPoint anMean, estLowerBound anMean, estUpperBound anMean,
-                estPoint anStdDev, estLowerBound anStdDev,
-                estUpperBound anStdDev)
+      writeCsv csvFile (desc,
+                        estPoint anMean, estLowerBound anMean,
+                        estUpperBound anMean, estPoint anStdDev,
+                        estLowerBound anStdDev, estUpperBound anStdDev)
       when (verbosity == Verbose || (ovEffect > Slight && verbosity > Quiet)) $ do
         when (verbosity == Verbose) $ noteOutliers reportOutliers
         _ <- note "variance introduced by outliers: %d%% (%s)\n"
@@ -131,9 +131,10 @@ runAndAnalyse p bs' = do
          | p name   = do
              envs' <- mapM mkEnv envs
              liftIO $ evaluate (rnf envs')
-             foldM go k [(ro', bench "" $ a e)
+             foldM go k [(ro', bench name $ a e)
                          |(aN, a) <- algs, (eN, e) <-envs',
-                          let ro' = addOwner ro $ ROVersus desc (show eN) aN]
+                          let name = aN ++ "/" ++ show eN
+                              ro' = addOwner ro $ ROVersus desc (show eN) aN]
          | otherwise = return (k :: Int)
          where mkEnv (t, mkenv) = liftIO $ do
                  e <- mkenv

--- a/Criterion/Internal.hs
+++ b/Criterion/Internal.hs
@@ -34,6 +34,7 @@ import Criterion.Measurement (runBenchmark, secs)
 import Criterion.Monad (Criterion)
 import Criterion.Report (report)
 import Criterion.Types hiding (measure)
+import Criterion.Versus (vscsv)
 import qualified Data.Map as Map
 import Statistics.Resampling.Bootstrap (Estimate(..))
 import System.Directory (getTemporaryDirectory, removeFile)
@@ -148,6 +149,7 @@ runAndAnalyse p bs' = do
 
   report rpts
   junit rpts
+  vscsv bs' rpts
 
 -- | Run a benchmark without analysing its performance.
 runNotAnalyse :: Int64            -- ^ Number of loop iterations to run.

--- a/Criterion/Internal.hs
+++ b/Criterion/Internal.hs
@@ -133,7 +133,7 @@ runAndAnalyse p bs' = do
              liftIO $ evaluate (rnf envs')
              foldM go k [(ro', bench undefined $ a e)
                          |(aN, a) <- algs, (eN, e) <-envs',
-                          let ro' = addOwner ro $ ROVersus desc aN eN]
+                          let ro' = addOwner ro $ ROVersus desc (show eN) aN]
          | otherwise = return (k :: Int)
          where mkEnv (t, mkenv) = liftIO $ do
                  e <- mkenv
@@ -151,7 +151,7 @@ runAndAnalyse p bs' = do
 
   report rpts
   junit rpts
-  vscsv bs' rpts
+  vscsv rpts
 
 -- | Run a benchmark without analysing its performance.
 runNotAnalyse :: Int64            -- ^ Number of loop iterations to run.

--- a/Criterion/Internal.hs
+++ b/Criterion/Internal.hs
@@ -138,7 +138,7 @@ runAndAnalyse p bs' = do
                    , vsReportIndices = [((aN, eN), i)|
                                         (i, (_, _, aN, eN)) <- zip [k..] indices]
                    }
-             (k', _) <- foldM go (k, undefined)
+             (k', _) <- foldM go (k, [])
                         [(desc', bench name $ a e)
                         | (a, e, aN, eN) <- indices
                         , let name = aN ++ "/" ++ show eN]

--- a/Criterion/Internal.hs
+++ b/Criterion/Internal.hs
@@ -158,7 +158,7 @@ runAndAnalyse p bs' = do
       Just _ -> return rs
       _      -> removeFile rawFile >> return rs
   let vsRpts' = versusReports vsRpts rpts
-  report rpts
+  report rpts vsRpts'
   junit rpts
   vscsv vsRpts'
 

--- a/Criterion/Main.hs
+++ b/Criterion/Main.hs
@@ -47,6 +47,7 @@ module Criterion.Main
 
 import Control.Monad (unless)
 import Control.Monad.Trans (liftIO)
+import Control.Monad.Reader (asks)
 import Criterion.IO.Printf (printError, writeCsv)
 import Criterion.Internal (runAndAnalyse, runNotAnalyse, addPrefix)
 import Criterion.Main.Options (MatchType(..), Mode(..), defaultConfig, describe,
@@ -146,8 +147,9 @@ defaultMainWith defCfg bs = do
     Run cfg matchType benches -> do
       shouldRun <- selectBenches matchType benches bsgroup
       withConfig cfg $ do
-        writeCsv ("Name","Mean","MeanLB","MeanUB","Stddev","StddevLB",
-                  "StddevUB")
+        file <- asks csvFile
+        writeCsv file ("Name","Mean","MeanLB","MeanUB","Stddev","StddevLB",
+                       "StddevUB")
         liftIO initializeTime
         runAndAnalyse shouldRun bsgroup
 

--- a/Criterion/Main.hs
+++ b/Criterion/Main.hs
@@ -31,6 +31,7 @@ module Criterion.Main
     , env
     , bench
     , bgroup
+    , bversus
     -- ** Running a benchmark
     , nf
     , whnf
@@ -99,6 +100,7 @@ selectBenches matchType benches bsgroup = do
   let go pfx (Environment _ b)     = go pfx (b undefined)
       go pfx (BenchGroup pfx' bms) = concatMap (go (addPrefix pfx pfx')) bms
       go pfx (Benchmark desc _)    = [addPrefix pfx desc]
+      go pfx (BenchVersus desc _ _) = [addPrefix pfx desc]
   toRun <- either parseError return . makeMatcher matchType $ benches
   unless (null benches || any toRun (go "" bsgroup)) $
     parseError "none of the specified names matches a benchmark"

--- a/Criterion/Main/Options.hs
+++ b/Criterion/Main/Options.hs
@@ -73,6 +73,7 @@ defaultConfig = Config {
     , reportFile   = Nothing
     , csvFile      = Nothing
     , junitFile    = Nothing
+    , vsCsvFile    = Nothing
     , verbosity    = Normal
     , template     = "default"
     }
@@ -122,6 +123,8 @@ config Config{..} = Config
                             help "file to write CSV summary to")
   <*> outputOption junitFile (long "junit" <>
                               help "file to write JUnit summary to")
+  <*> outputOption vsCsvFile (long "vscsv" <>
+                              help "file to write \"versus\"-type benchmark groups to")
   <*> (toEnum <$> option (range 0 2)
                   (long "verbosity" <> short 'v' <> metavar "LEVEL" <>
                    value (fromEnum verbosity) <>

--- a/Criterion/Report.hs
+++ b/Criterion/Report.hs
@@ -95,12 +95,13 @@ formatReport reports vsreports template = do
       context "vsjson"   = return $ MuVariable $ encode vsreports'
       context "include"  = return $ MuLambdaM $ includeFile [templates]
       context "vsreport" = return $ MuList $ map vsinner vsreports'
-      context _         = return $ MuNothing
+      context _          = return MuNothing
       encode v = TL.toLazyText . encodeToTextBuilder . toJSON $ v
-      vsinner (n, r@VersusReport{..}) = mkStrContextM $ \case
+      vsinner (n, VersusReport{..}) = mkStrContextM $ \case
                            "number"   -> return . MuVariable $ encode n
                            "name"     -> return . MuVariable . H.htmlEscape .
                                          TL.pack $ vsReportDescription
+                           _          -> return MuNothing
       inner r@Report{..} = mkStrContextM $ \nym ->
                          case nym of
                            "name"     -> return . MuVariable . H.htmlEscape .

--- a/Criterion/Types.hs
+++ b/Criterion/Types.hs
@@ -335,7 +335,7 @@ data Benchmark where
     Environment  :: NFData env => IO env -> (env -> Benchmark) -> Benchmark
     Benchmark    :: String -> Benchmarkable -> Benchmark
     BenchGroup   :: String -> [Benchmark] -> Benchmark
-    BenchVersus  :: (NFData a, Show l, Num l, NFData l) => String ->
+    BenchVersus  :: (NFData a, Show l, Ord l, NFData l) => String ->
                     [(l, IO a)] -> [(String, a -> Benchmarkable)] -> Benchmark
 
 -- | Run a benchmark (or collection of benchmarks) in the given
@@ -435,14 +435,14 @@ bgroup :: String                -- ^ A name to identify the group of benchmarks.
        -> Benchmark
 bgroup = BenchGroup
 
-bversus :: (NFData a, Show l, Num l) =>
+bversus :: (NFData a, Show l, Ord l, NFData l) =>
            String
         -> [(l, IO a)]
         -> [(String, a -> Benchmarkable)]
         -> Benchmark
 bversus = BenchVersus
 
-vsList :: (NFData a, Show a, Num a) =>
+vsList :: (NFData a, Show a, Ord a) =>
           String
        -> [a]
        -> [(String, a -> Benchmarkable)]

--- a/Criterion/Types.hs
+++ b/Criterion/Types.hs
@@ -634,8 +634,8 @@ type ReportOwner = [ROType]
 data ROType = ROBench String
             | ROGroup String
             | ROVersus {
-                roTypeVsTag 
-              , roTypeVsEnv
+                roTypeVsTag :: String
+              , roTypeVsEnv 
               , roTypeVsAlg :: String
               }
             deriving (Eq, Read, Show, Typeable, Data, Generic)
@@ -664,7 +664,7 @@ addOwner = flip (:)
 reportOwnerToName :: ReportOwner
                   -> String
 reportOwnerToName = intercalate "/" . filter (not . null) . map f . reverse
-  where f (ROVersus d e a) = d ++ "/" ++ e ++ "/" ++ a
+  where f (ROVersus d _ _) = d
         f (ROGroup d)      = d
         f (ROBench d)      = d
 

--- a/Criterion/Types.hs
+++ b/Criterion/Types.hs
@@ -435,12 +435,26 @@ bgroup :: String                -- ^ A name to identify the group of benchmarks.
        -> Benchmark
 bgroup = BenchGroup
 
+-- | Perform several algorithms on a set of data samples
+-- and compare their performance.
+-- 
+-- __Example.__ Compare performance of different summation algorithms:
+-- 
+-- > main = defaultMain [
+-- >          bversus "sum"
+-- >            [ (i, return [1..i]) | i<-[(100::Int), 200 .. 600]]
+-- >            [ ("prelude", nf sum)
+-- >            , ("foldr1", nf $ foldr1 (+))
+-- >            , ("foldl'", nf $ foldl' (+) 0)
+-- >            ]
+-- >          ]
 bversus :: (NFData a, Show l, Ord l, NFData l) =>
-           String
-        -> [(l, IO a)]
-        -> [(String, a -> Benchmarkable)]
+           String                          -- ^ A name to identify group
+        -> [(l, IO a)]                     -- ^ A set of test data
+        -> [(String, a -> Benchmarkable)]  -- ^ A set of algorithms
         -> Benchmark
 bversus = BenchVersus
+
 
 vsList :: (NFData a, Show a, Ord a) =>
           String

--- a/Criterion/Types.hs
+++ b/Criterion/Types.hs
@@ -109,6 +109,8 @@ data Config = Config {
       -- ^ File to write CSV summary to.
     , junitFile    :: Maybe FilePath
       -- ^ File to write JUnit-compatible XML results to.
+    , vsCsvFile    :: Maybe FilePath
+      -- ^ CSV file to write 'versus'-type benchmark groups to.
     , verbosity    :: Verbosity
       -- ^ Verbosity level to use when running and analysing
       -- benchmarks.

--- a/Criterion/Versus.hs
+++ b/Criterion/Versus.hs
@@ -12,8 +12,7 @@
 
 module Criterion.Versus
        (
-         versusReports
-       , vscsv
+         vscsv
        ) where
 
 import Criterion.Types
@@ -24,35 +23,12 @@ import Data.Csv as Csv
 import qualified Data.Map as M
 import Data.List (isPrefixOf, stripPrefix, find)
 import Statistics.Resampling.Bootstrap (Estimate)
-
-getVs :: String
-      -> Benchmark
-      -> [Benchmark]
-getVs p (Environment _ b)     = getVs p $ b undefined
-getVs _ (Benchmark _ _)       = []
-getVs p (BenchGroup d b)      = b >>= getVs (p++d++"/")
-getVs p (BenchVersus d e a)   = [BenchVersus (p++d) e a]
-
-data VersusReport = VersusReport [String, ]
-
-versusReport :: Benchmark
-          -> [Report]
-          -> Maybe VersusReport
-versusReport bnch reps = do
-  let vss = getVs "" bnch
-      vss' = zip vss $ replicate M.empty
-      f m Report {reportName = n, reportAnalysis = a} =
-        case find (\i -> isPrefixOf a n) vss of
-         Just s  -> M.update () s m 
-         Nothing -> m
-         where 
-      vs  = foldl f vss' reps
-  
   
 vscsv :: Benchmark
       -> [Report]
       -> Criterion ()
 vscsv b r = do
-  liftIO $ print b
-  liftIO $ forM_ r $ \i -> putStr (reportName i) >> putStr " -> " >> print (anMean $ reportAnalysis i)
+  -- liftIO $ print b
+  -- liftIO $ forM_ r $ \i -> putStr (reportName i) >> putStr " -> " >> print (anMean $ reportAnalysis i)
+  return ()
 

--- a/Criterion/Versus.hs
+++ b/Criterion/Versus.hs
@@ -23,11 +23,12 @@ import Data.Csv as Csv
 import qualified Data.Map as M
 import Data.List (isPrefixOf, stripPrefix, find)
 import Statistics.Resampling.Bootstrap (Estimate)
-  
-vscsv :: Benchmark
-      -> [Report]
+
+data VersusReport = VersusReport String [((String, String), Estimate)]
+
+vscsv :: [Report]
       -> Criterion ()
-vscsv b r = do
+vscsv r = do
   -- liftIO $ print b
   -- liftIO $ forM_ r $ \i -> putStr (reportName i) >> putStr " -> " >> print (anMean $ reportAnalysis i)
   return ()

--- a/Criterion/Versus.hs
+++ b/Criterion/Versus.hs
@@ -13,23 +13,55 @@
 module Criterion.Versus
        (
          vscsv
+       , versusReport
        ) where
 
 import Criterion.Types
 import Criterion.Monad (Criterion)
 import Control.Monad.Trans (liftIO)
 import Control.Monad
+import Control.Arrow ((&&&))
+import Data.Function (on)
 import Data.Csv as Csv
 import qualified Data.Map as M
-import Data.List (isPrefixOf, stripPrefix, find)
+import Data.List (groupBy)
 import Statistics.Resampling.Bootstrap (Estimate)
 
-data VersusReport = VersusReport String [((String, String), Estimate)]
+data VersusReport = VersusReport {
+      vsReportDescription :: String
+    , vsReportData :: [(String, [(String, Estimate)])]
+    } deriving (Eq, Show, Read)
 
-vscsv :: [Report]
-      -> Criterion ()
-vscsv r = do
-  -- liftIO $ print b
-  -- liftIO $ forM_ r $ \i -> putStr (reportName i) >> putStr " -> " >> print (anMean $ reportAnalysis i)
-  return ()
+isVersus :: Report -> Bool
+isVersus r = case reportOwner r of
+              (_ : ROVersus _ _ _ : _) -> True
+              _                        -> False
 
+vs :: Report -> ReportOwner
+vs = tail . reportOwner
+
+alg :: Report -> String
+alg = roTypeVsAlg . head . vs
+
+benv :: Report -> String
+benv = roTypeVsEnv . head . vs
+
+eqVs :: ReportOwner -> ReportOwner -> Bool
+eqVs (ROVersus d1 _ _:t1) (ROVersus d2 _ _ :t2) = d1 == d2 && t1 == t2
+eqVs _ _ = error "eqVs: shouldn't happen"
+
+versusName :: ReportOwner -> String
+versusName (v:t) = reportOwnerToName $ ROBench (roTypeVsTag v) : t
+
+groupAlgs :: [Report] -> [(String, [(String, Estimate)])]
+groupAlgs r = map f r'
+  where r' = groupBy ((==)`on`alg) r
+        f = alg . head &&& map (benv &&& anMean . reportAnalysis)
+
+groupBGroups :: [Report] -> [(String, [Report])]
+groupBGroups r = map ((versusName . vs . head) &&& id) r'
+  where r' = groupBy (eqVs `on` vs) $ filter isVersus r
+
+versusReport :: [Report] -> [VersusReport]
+versusReport r = map (\(t, l) -> VersusReport t $ groupAlgs l) rr
+  where rr  = groupBGroups r

--- a/Criterion/Versus.hs
+++ b/Criterion/Versus.hs
@@ -28,6 +28,7 @@ import Data.Function (on)
 import Data.Csv as Csv
 import Data.List (groupBy, sortBy)
 import Statistics.Resampling.Bootstrap (Estimate(..))
+import Data.Aeson (ToJSON(..))
 
 data VersusReport where
   VersusReport :: (Show l, Ord l) => {
@@ -38,6 +39,15 @@ data VersusReport where
   } -> VersusReport
 deriving instance Show VersusReport
 
+instance ToJSON VersusReport where
+  toJSON VersusReport{
+      vsReportDescription = desc
+    , vsReportDataPoints  = dp
+    , vsReportData        = d
+    , vsReportIndices     = i
+    } =
+    toJSON (desc, map show dp, d)
+
 vscsv :: [VersusReport] -> Criterion ()
 vscsv = mapM_ f
   where f VersusReport{
@@ -47,7 +57,7 @@ vscsv = mapM_ f
           file <- asks vsCsvFile
           writeCsv file [d]
           writeCsv file $ "name":(map show p)
-          forM_ r $ \(a, m) -> writeCsv file $ a:(map show m)
+          forM_ r $ \(a, m) -> writeCsv file $ a:(map (show . estPoint) m)
 
 versusReports :: [VersusReport] -> [Report] -> [VersusReport]
 versusReports vrpts rpts = map (vsReport rpts) vrpts

--- a/Criterion/Versus.hs
+++ b/Criterion/Versus.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE BangPatterns, RecordWildCards #-}
+-- |
+-- Module      : Criterion
+-- Copyright   : (c) 2009-2014 Bryan O'Sullivan
+--
+-- License     : BSD-style
+-- Maintainer  : bos@serpentine.com
+-- Stability   : experimental
+-- Portability : GHC
+--
+-- 'Versus'-type bgroup support
+
+module Criterion.Versus
+       (
+         getVsNames
+       , vscsv
+       ) where
+
+import Criterion.Types
+import Criterion.Monad (Criterion)
+import Control.Monad.Trans (liftIO)
+import Control.Monad
+import Data.Csv as Csv
+
+getVsNames :: Benchmark -> [String]
+getVsNames (Environment _ b)   = getVsNames $ b undefined
+getVsNames (Benchmark _ _)     = []
+getVsNames (BenchGroup d b)    = map ((d ++ "/") ++) $ b >>= getVsNames
+getVsNames (BenchVersus d _ _) = [d]
+
+vscsv :: Benchmark
+      -> [Report]
+      -> Criterion ()
+vscsv b r = do
+  liftIO $ print b
+  liftIO $ forM_ r $ \i -> putStr (reportName i) >> putStr " -> " >> print (anMean $ reportAnalysis i)

--- a/Criterion/Versus.hs
+++ b/Criterion/Versus.hs
@@ -35,6 +35,7 @@ data VersusReport = VersusReport {
     , vsReportData :: [(String, [Estimate])]
     } deriving (Eq, Show, Read)
 
+{-
 isVersus :: Report -> Bool
 isVersus r = case reportOwner r of
               (_ : ROVersus _ _ _ : _) -> True
@@ -72,3 +73,8 @@ vscsv rpts = do
     writeCsv file [vsReportDescription r]
     writeCsv file $ "Name" : vsReportDataPoints r
     --forM_ d $ \(a, f) -> writeCsv file $ a : map (show.estPoint.snd) f
+-}
+
+vscsv = undefined
+
+versusReport = undefined

--- a/Criterion/Versus.hs
+++ b/Criterion/Versus.hs
@@ -45,7 +45,6 @@ instance ToJSON VersusReport where
       vsReportDescription = desc
     , vsReportDataPoints  = dp
     , vsReportData        = d
-    , vsReportIndices     = i
     } = object [ "name"       .= toJSON desc
                , "dataPoints" .= toJSON (map show dp)
                , "data"       .= toJSON (map mkArr d)]
@@ -72,12 +71,12 @@ vsReport :: [Report] -> VersusReport -> VersusReport
 vsReport rpts vr@VersusReport{vsReportIndices = indices} =
   vr{vsReportData = map f l}
   where
-    alg = fst . fst
-    env = snd . fst
-    l   = groupBy' ((==) `on` alg) alg indices
+    valg = fst . fst
+    venv = snd . fst
+    l    = groupBy' ((==) `on` valg) valg indices
     rpts' = sortBy (compare `on` reportNumber) rpts
     f (alg, idx) = (alg, [anMean . reportAnalysis $ rpts'!!i
-                         | (_, i)<-sortBy (compare `on` env) idx])
+                         | (_, i)<-sortBy (compare `on` venv) idx])
 
 groupBy' :: (a -> a -> Bool) -> (a -> b) -> [a] -> [(b, [a])]
 groupBy' f g = map (g . head &&& id) . groupBy f

--- a/criterion.cabal
+++ b/criterion.cabal
@@ -54,6 +54,7 @@ library
     Criterion.Monad
     Criterion.Report
     Criterion.Types
+    Criterion.Versus
 
   other-modules:
     Criterion.Monad.Internal

--- a/templates/default.tpl
+++ b/templates/default.tpl
@@ -26,12 +26,18 @@
       <div id="main" class="body">
     <h1>criterion performance measurements</h1>
 
+{{#vsreport}}
+<h2>{{name}}</h2>
+<div id="vsp_{{number}}" class="vschart"
+     style="width:900;height:278px;">
+</div>
+{{/vsreport}}
+
 <h2>overview</h2>
 
 <p><a href="#grokularation">want to understand this report?</a></p>
 
 <div id="overview" class="ovchart" style="width:900px;height:100px;"></div>
-
 {{#report}}
 <h2><a name="b{{number}}">{{name}}</a></h2>
  <table width="100%">
@@ -271,9 +277,31 @@ $(function () {
       $.addTooltip("#cycles" + number, function(x,y) { return x + ' cycles'; });
     }
   };
+  function vsreport(rpt) {
+    var number = rpt[0];
+    var name = rpt[1].name;
+    var points = rpt[1].dataPoints;
+    var data = rpt[1].data;
+    var pl = $("#vsp_" + number);
+    var pldata = [];
+    data.forEach(function(dat) {
+      var arr = [];
+      for(var i = 0; i < points.length; i++) {
+        arr.push([points[i], dat.data[i].estPoint]);
+      }
+      pldata.push({ label: dat.alg, 
+                    data: arr,
+                    points: { show: true },
+                    lines: { show: true }
+                 });
+    });
+    console.log(pldata);
+    $.plot(pl, pldata);
+  };
   var reports = {{json}};
+  var vsreports = {{vsjson}};
   reports.map(mangulate);
-
+  vsreports.map(vsreport);
   var benches = [{{#report}}"{{name}}",{{/report}}];
   var ylabels = [{{#report}}[-{{number}},'<a href="#b{{number}}">{{name}}</a>'],{{/report}}];
   var means = $.scaleTimes([{{#report}}{{anMean.estPoint}},{{/report}}]);


### PR DESCRIPTION
Hello,

First of all, thanks for your fantastic library. It has proven itself very useful for choosing an optimal implementation. Speaking of which, I tried to make results a bit more vivid by introducing performance comparison graphs like this:
 
![vsgraph](https://cloud.githubusercontent.com/assets/10274441/6177952/b82bd096-b31b-11e4-9361-b116a789fd0d.png)

It can be done using a new API (bversus is like a special kind of groups). Simple example:

```haskell
main = defaultMain [bgroup "foo" [
                       bversus "sum" [(i,) `fmap` replicateM i $
                                        randomRIO (0::Int, 100)
                                       | i<-[100, 200, 400, 800, 1600]]
                         [
                           ("prelude", nf sum)
                         , ("foldl'", nf $ foldl' (+) 0)
                         , ("foldr", nf $ foldr (+) 0)
                         ]
                       ]
                   ]
```

I have to admit that the quality of code may be not very good and there is a room for improvement. Moreover, I haven't touched JS before, so the quality of the JS code is probably horrific.

Anyway, I would be grateful if you look through this feature and say if it worth further development.