### PR TITLE
Restore compat with GHC 7.4

### DIFF
--- a/criterion.cabal
+++ b/criterion.cabal
@@ -116,6 +116,9 @@ executable criterion
     base,
     criterion,
     optparse-applicative
+  if impl(ghc < 7.6)
+    build-depends:
+      ghc-prim
 
 test-suite sanity
   type:           exitcode-stdio-1.0


### PR DESCRIPTION
Without this fix, GHC 7.4.2 fails to install `criterion` with:

```
app/Options.hs:13:8:
    Could not find module `GHC.Generics'
    It is a member of the hidden package `ghc-prim'.
    Perhaps you need to add `ghc-prim' to the build-depends in your .cabal file.
    Use -v to see a list of the files searched for.
```