### PR TITLE
Add JSON Report serialization as an alternative to `--raw`

### DIFF
--- a/Criterion/IO.hs
+++ b/Criterion/IO.hs
@@ -13,6 +13,7 @@
 module Criterion.IO
     (
       header
+    , headerRoot
     , hGetRecords
     , hPutRecords
     , readRecords
@@ -26,7 +27,7 @@ import Data.Binary.Get (runGetOrFail)
 import Data.Binary.Get (runGetState)
 #endif
 import Data.Binary.Put (putByteString, putWord16be, runPut)
-import Data.ByteString.Char8 ()
+import qualified Data.ByteString.Char8 as B
 import Data.Version (Version(..))
 import Paths_criterion (version)
 import System.IO (Handle, IOMode(..), withFile)
@@ -37,8 +38,12 @@ import qualified Data.ByteString.Lazy as L
 -- compatibility.
 header :: L.ByteString
 header = runPut $ do
-  putByteString "criterio"
+  putByteString (B.pack headerRoot)
   mapM_ (putWord16be . fromIntegral) (versionBranch version)
+
+-- | The magic string we expect to start off the header.
+-- headerRoot :: String
+headerRoot = "criterio"
 
 -- | Read all records from the given 'Handle'.
 hGetRecords :: Binary a => Handle -> IO (Either String [a])

--- a/Criterion/Internal.hs
+++ b/Criterion/Internal.hs
@@ -25,13 +25,11 @@ import Control.Monad (foldM, forM_, void, when)
 import Control.Monad.Reader (ask, asks)
 import Control.Monad.Trans (MonadIO, liftIO)
 import Control.Monad.Trans.Except
-import qualified Data.Aeson as Aeson (encode)
 import qualified Data.Binary as Binary (encode)
 import Data.Int (Int64)
-import Data.List (intercalate)
 import qualified Data.ByteString.Lazy as L
 import Criterion.Analysis (analyseSample, noteOutliers)
-import Criterion.IO (header, headerRoot, hGetRecords)
+import Criterion.IO (header, writeJSONReports, hGetRecords)
 import Criterion.IO.Printf (note, printError, prolix, writeCsv)
 import Criterion.Measurement (runBenchmark, secs)
 import Criterion.Monad (Criterion)
@@ -39,8 +37,6 @@ import Criterion.Report (report)
 import Criterion.Types hiding (measure)
 import qualified Data.Map as Map
 import Data.Vector (Vector)
-import Data.Version (Version(..))
-import Paths_criterion (version)
 import Statistics.Resampling.Bootstrap (Estimate(..))
 import System.Directory (getTemporaryDirectory, removeFile)
 import System.IO (IOMode(..), SeekMode(..), hClose, hSeek, openBinaryFile,
@@ -184,9 +180,7 @@ json :: [Report] -> Criterion ()
 json rs
   = do jsonOpt <- asks jsonFile
        case jsonOpt of
-         Just fn -> liftIO . L.writeFile fn $ Aeson.encode
-                     (headerRoot,
-                      intercalate "." $ map show $ versionBranch version, rs)
+         Just fn -> liftIO $ writeJSONReports fn rs
          Nothing -> return ()
 
 -- | Write summary JUnit file (if applicable)

--- a/Criterion/Internal.hs
+++ b/Criterion/Internal.hs
@@ -28,9 +28,10 @@ import Control.Monad.Trans.Except
 import qualified Data.Aeson as Aeson (encode)
 import qualified Data.Binary as Binary (encode)
 import Data.Int (Int64)
+import Data.List (intercalate)
 import qualified Data.ByteString.Lazy as L
 import Criterion.Analysis (analyseSample, noteOutliers)
-import Criterion.IO (header, hGetRecords)
+import Criterion.IO (header, headerRoot, hGetRecords)
 import Criterion.IO.Printf (note, printError, prolix, writeCsv)
 import Criterion.Measurement (runBenchmark, secs)
 import Criterion.Monad (Criterion)
@@ -38,6 +39,8 @@ import Criterion.Report (report)
 import Criterion.Types hiding (measure)
 import qualified Data.Map as Map
 import Data.Vector (Vector)
+import Data.Version (Version(..))
+import Paths_criterion (version)
 import Statistics.Resampling.Bootstrap (Estimate(..))
 import System.Directory (getTemporaryDirectory, removeFile)
 import System.IO (IOMode(..), SeekMode(..), hClose, hSeek, openBinaryFile,
@@ -181,7 +184,9 @@ json :: [Report] -> Criterion ()
 json rs
   = do jsonOpt <- asks jsonFile
        case jsonOpt of
-         Just fn -> liftIO . L.writeFile fn $ Aeson.encode rs
+         Just fn -> liftIO . L.writeFile fn $ Aeson.encode
+                     (headerRoot,
+                      intercalate "." $ map show $ versionBranch version, rs)
          Nothing -> return ()
 
 -- | Write summary JUnit file (if applicable)

--- a/Criterion/Main/Options.hs
+++ b/Criterion/Main/Options.hs
@@ -72,6 +72,7 @@ defaultConfig = Config {
     , rawDataFile  = Nothing
     , reportFile   = Nothing
     , csvFile      = Nothing
+    , jsonFile     = Nothing
     , junitFile    = Nothing
     , verbosity    = Normal
     , template     = "default"
@@ -120,6 +121,8 @@ config Config{..} = Config
                                help "File to write report to")
   <*> outputOption csvFile (long "csv" <>
                             help "File to write CSV summary to")
+  <*> outputOption jsonFile (long "json" <>
+                             help "File to write JSON summary to")
   <*> outputOption junitFile (long "junit" <>
                               help "File to write JUnit summary to")
   <*> (toEnum <$> option (range 0 2)

--- a/Criterion/Types.hs
+++ b/Criterion/Types.hs
@@ -173,8 +173,15 @@ data Measured = Measured {
 instance FromJSON Measured where
     parseJSON v = do
       (a,b,c,d,e,f,g,h,i,j,k) <- parseJSON v
-      return $ Measured a b c d e f g h i j k
+      -- The first four fields are not subject to the encoding policy:
+      return $ Measured a b c d
+                       (int e) (int f) (int g)
+                       (db h) (db i) (db j) (db k)
+      where int = toInt; db = toDouble
 
+-- Here we treat the numeric fields as `Maybe Int64` and `Maybe Double`
+-- and we use a specific policy for deciding when they should be Nothing,
+-- which becomes null in JSON.
 instance ToJSON Measured where
     toJSON Measured{..} = toJSON
       (measTime, measCpuTime, measCycles, measIters,

--- a/Criterion/Types.hs
+++ b/Criterion/Types.hs
@@ -108,6 +108,8 @@ data Config = Config {
       -- ^ File to write report output to, with template expanded.
     , csvFile      :: Maybe FilePath
       -- ^ File to write CSV summary to.
+    , jsonFile     :: Maybe FilePath
+      -- ^ File to write JSON-formatted results to.
     , junitFile    :: Maybe FilePath
       -- ^ File to write JUnit-compatible XML results to.
     , verbosity    :: Verbosity

--- a/www/tutorial.md
+++ b/www/tutorial.md
@@ -492,9 +492,9 @@ only other template provided by default is `json`, so if you run with
 `--template json --output mydata.json`, you'll get a big JSON dump of
 your data.
 
-You can also write out a basic CSV file using `--csv`, and a
-JUnit-compatible XML file using `--junit`.  (The contents of these
-files are likely to change in the not-too-distant future.)
+You can also write out a basic CSV file using `--csv`, a JSON file using
+`--json`, and a JUnit-compatible XML file using `--junit`.  (The contents
+of these files are likely to change in the not-too-distant future.)
 
 
 # Linear regression


### PR DESCRIPTION
We've been using this in our benchmarking and it completely removes our dependence on the (buggy) `--raw` output.

@RyanGLScott should be able to confirm that all 1800 stackage benchmarks run while using JSON serialization internally.  (That is, during the benchmarking loop, reports are written out and read back in in json format.)  This fixes a number of failing cases within those stackage benchmarks.