### PR TITLE
cbits/cycles.c: Restore support for 32 bit Intel CPUs

### DIFF
--- a/cbits/cycles.c
+++ b/cbits/cycles.c
@@ -1,6 +1,6 @@
 #include "Rts.h"
 
-#if x86_64_HOST_ARCH
+#if x86_64_HOST_ARCH || i386_HOST_ARCH
 
 StgWord64 criterion_rdtsc(void)
 {


### PR DESCRIPTION
Tested on i386 and x86_64 Linux.