### PR TITLE
#107, open the output file in the write mode

### DIFF
--- a/Criterion/Internal.hs
+++ b/Criterion/Internal.hs
@@ -117,7 +117,7 @@ runAndAnalyse select bs = do
         tmpDir <- getTemporaryDirectory
         openTempFile tmpDir "criterion.json"
       Just file -> do
-        handle <- openFile file ReadWriteMode
+        handle <- openFile file WriteMode
         return (file, handle)
   -- The type we write to the file is ReportFileContents, a triple.
   -- But here we ASSUME that the tuple will become a JSON array.


### PR DESCRIPTION
With ReadWriteMode Haskell opens the file but doesn't truncate the contents. That means if we have a file there from before, we end up overwriting the start, and if the file was longer, we end up with corrupt JSON. Only visible if you run the test suite multiple times, and somewhat non-deterministic since it requires longer times (when printed in exponential format), followed by shorter times.