### PR TITLE
Fix link to examples in README.markdown

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -10,7 +10,7 @@ measuring and analysing software performance.
 To get started, read the <a
 href="http://www.serpentine.com/criterion/tutorial.html"
 target="_blank">online tutorial</a>, and take a look at the programs
-in the <a href="/bos/criterion/tree/master/examples"
+in the <a href="/examples"
 target="_blank">examples directory</a>.
 
 


### PR DESCRIPTION
GitHub link processing magic takes care of adding the right repo & branch.