### PR TITLE
Fix build with statistics 0.14

### DIFF
--- a/Criterion/Internal.hs
+++ b/Criterion/Internal.hs
@@ -37,7 +37,7 @@ import Criterion.Report (report)
 import Criterion.Types hiding (measure)
 import qualified Data.Map as Map
 import qualified Data.Vector as V
-import Statistics.Resampling.Bootstrap (Estimate(..))
+import Statistics.Types (Estimate(..),ConfInt(..),confidenceInterval,cl95,confLevel)
 import System.Directory (getTemporaryDirectory, removeFile)
 import System.IO (IOMode(..), hClose, openTempFile, openFile, hPutStr, openBinaryFile)
 import Text.Printf (printf)
@@ -79,10 +79,11 @@ analyseOne i desc meas = do
         _ <- bs r2 (regResponder ++ ":") regRSquare
         forM_ (Map.toList regCoeffs) $ \(prd,val) ->
           bs (printf "%.3g") ("  " ++ prd) val
-      writeCsv (desc,
-                estPoint anMean, estLowerBound anMean, estUpperBound anMean,
-                estPoint anStdDev, estLowerBound anStdDev,
-                estUpperBound anStdDev)
+      writeCsv
+        (desc,
+         estPoint anMean,   fst $ confidenceInterval anMean,   snd $ confidenceInterval anMean,
+         estPoint anStdDev, fst $ confidenceInterval anStdDev, snd $ confidenceInterval anStdDev
+        )
       when (verbosity == Verbose || (ovEffect > Slight && verbosity > Quiet)) $ do
         when (verbosity == Verbose) $ noteOutliers reportOutliers
         _ <- note "variance introduced by outliers: %d%% (%s)\n"
@@ -90,12 +91,16 @@ analyseOne i desc meas = do
         return ()
       _ <- note "\n"
       return (Analysed rpt)
-      where bs :: (Double -> String) -> String -> Estimate -> Criterion ()
-            bs f metric Estimate{..} =
+      where bs :: (Double -> String) -> String -> Estimate ConfInt Double -> Criterion ()
+            bs f metric e@Estimate{..} =
               note "%-20s %-10s (%s .. %s%s)\n" metric
-                   (f estPoint) (f estLowerBound) (f estUpperBound)
-                   (if estConfidenceLevel == 0.95 then ""
-                    else printf ", ci %.3f" estConfidenceLevel)
+                   (f estPoint) (f $ fst $ confidenceInterval e) (f $ snd $ confidenceInterval e)
+                   (let cl = confIntCL estError
+                        str | cl == cl95 = ""
+                            | otherwise  = printf ", ci %.3f" (confLevel cl)
+                    in str
+                   )
+
 
 -- | Run a single benchmark and analyse its performance.
 runAndAnalyseOne :: Int -> String -> Benchmarkable -> Criterion DataRecord

--- a/Criterion/Main/Options.hs
+++ b/Criterion/Main/Options.hs
@@ -39,6 +39,7 @@ import Options.Applicative.Help (Chunk(..), tabulate)
 import Options.Applicative.Help.Pretty ((.$.))
 import Options.Applicative.Types
 import Paths_criterion (version)
+import Statistics.Types (mkConfLevel,cl95)
 import Text.PrettyPrint.ANSI.Leijen (Doc, text)
 import qualified Data.Map as M
 import Prelude
@@ -67,7 +68,7 @@ data Mode = List
 -- | Default benchmarking configuration.
 defaultConfig :: Config
 defaultConfig = Config {
-      confInterval = 0.95
+      confInterval = cl95
     , forceGC      = True
     , timeLimit    = 5
     , resamples    = 1000
@@ -104,7 +105,7 @@ parseWith cfg =
 
 config :: Config -> Parser Config
 config Config{..} = Config
-  <$> option (range 0.001 0.999)
+  <$> option (mkConfLevel <$> range 0.001 0.999)
       (long "ci" <> short 'I' <> metavar "CI" <> value confInterval <>
        help "Confidence interval")
   <*> (not <$> switch (long "no-gc" <> short 'G' <>

--- a/Criterion/Types.hs
+++ b/Criterion/Types.hs
@@ -77,7 +77,8 @@ import Data.Map (Map, fromList)
 import GHC.Generics (Generic)
 import qualified Data.Vector as V
 import qualified Data.Vector.Unboxed as U
-import qualified Statistics.Resampling.Bootstrap as B
+import qualified Statistics.Types as St
+import           Statistics.Resampling.Bootstrap ()
 import Prelude
 
 -- | Control the amount of information displayed.
@@ -89,7 +90,7 @@ data Verbosity = Quiet
 
 -- | Top-level benchmarking configuration.
 data Config = Config {
-      confInterval :: Double
+      confInterval :: St.CL Double
       -- ^ Confidence interval for bootstrap estimation (greater than
       -- 0, less than 1).
     , forceGC      :: Bool
@@ -550,9 +551,9 @@ instance NFData OutlierVariance where
 data Regression = Regression {
     regResponder  :: String
     -- ^ Name of the responding variable.
-  , regCoeffs     :: Map String B.Estimate
+  , regCoeffs     :: Map String (St.Estimate St.ConfInt Double)
     -- ^ Map from name to value of predictor coefficients.
-  , regRSquare    :: B.Estimate
+  , regRSquare    :: St.Estimate St.ConfInt Double
     -- ^ R&#0178; goodness-of-fit estimate.
   } deriving (Eq, Read, Show, Typeable, Data, Generic)
 
@@ -574,9 +575,9 @@ data SampleAnalysis = SampleAnalysis {
     , anOverhead   :: Double
       -- ^ Estimated measurement overhead, in seconds.  Estimation is
       -- performed via linear regression.
-    , anMean       :: B.Estimate
+    , anMean       :: St.Estimate St.ConfInt Double
       -- ^ Estimated mean.
-    , anStdDev     :: B.Estimate
+    , anStdDev     :: St.Estimate St.ConfInt Double
       -- ^ Estimated standard deviation.
     , anOutlierVar :: OutlierVariance
       -- ^ Description of the effects of outliers on the estimated

--- a/criterion.cabal
+++ b/criterion.cabal
@@ -1,5 +1,5 @@
 name:           criterion
-version:        1.1.3.0
+version:        1.2.0.0
 synopsis:       Robust, reliable performance measurement and analysis
 license:        BSD3
 license-file:   LICENSE
@@ -86,7 +86,7 @@ library
     mwc-random >= 0.8.0.3,
     optparse-applicative >= 0.11,
     parsec >= 3.1.0,
-    statistics >= 0.13.2.1,
+    statistics >= 0.14,
     text >= 0.11,
     time,
     transformers,


### PR DESCRIPTION
Support for new (not yet released) statistics 0.14. Major version bump is required because new types from statistics leak into public API.

There's also need for coordinated release of statistics and criterion. I can upload statistics but can't upload new criterion

P.S. I won't be available till Monday.
