### PR TITLE
Implement get for Binary Regression instance

### DIFF
--- a/Criterion/Types.hs
+++ b/Criterion/Types.hs
@@ -65,8 +65,8 @@ module Criterion.Types
     ) where
 
 -- Temporary: to support pre-AMP GHC 7.8.4:
-import Control.Applicative 
-import Data.Monoid 
+import Control.Applicative
+import Data.Monoid
 
 import Control.DeepSeq (NFData(rnf))
 import Control.Exception (evaluate)
@@ -563,6 +563,7 @@ instance ToJSON Regression
 instance Binary Regression where
     put Regression{..} =
       put regResponder >> put regCoeffs >> put regRSquare
+    get = Regression <$> get <*> get <*> get
 
 instance NFData Regression where
     rnf Regression{..} =


### PR DESCRIPTION
For some reason, it's not currently implemented, and it's resulted in [at least one sporadic failure](https://travis-ci.org/RyanGlScott/text-show/jobs/151838151#L1835) for me during benchmarking. I'm not sure _why_ it's sporadic, but luckily it's an easy fix.