### PR TITLE
Ensure criterion prints ² in an UTF-8 codepage on Windows

### DIFF
--- a/criterion.cabal
+++ b/criterion.cabal
@@ -96,6 +96,9 @@ library
   if impl(ghc < 7.6)
     build-depends:
       ghc-prim
+  if os(windows)
+    build-depends:
+      Win32
 
   ghc-options: -O2 -Wall -funbox-strict-fields
   if impl(ghc >= 6.8)


### PR DESCRIPTION
Tested on Windows 10 (64-bit). Fixes #100.
