### PR TITLE
Give more comprehensive changelog for 1.1.4.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,12 +1,27 @@
 
-1.1.3.1
+1.1.4.0
 
 * Add Safe Haskell annotations.
 
-1.1.3.0
-
 * Add `--json` option for writing reports in JSON rather than binary
   format.  Also: various bugfixes related to this.
+
+* Use the `js-jquery` and `js-flot` libraries to substitute in JavaScript code
+  into the default HTML report template.
+
+* Use the `code-page` library to ensure that `criterion` prints out Unicode
+  characters (like ², which `criterion` uses in reports) in a UTF-8-compatible
+  code page on Windows.
+
+* Give an explicit implementation for `get` in the `Binary Regression`
+  instance. This should fix sporadic `criterion` failures with older versions
+  of `binary`.
+
+* Use `tasty` instead of `test-framework` in the test suites.
+
+* Restore support for 32-bit Intel CPUs.
+
+* Restore build compatibilty with GHC 7.4.
 
 1.1.1.0
 

--- a/criterion.cabal
+++ b/criterion.cabal
@@ -1,5 +1,5 @@
 name:           criterion
-version:        1.1.3.1
+version:        1.1.4.0
 synopsis:       Robust, reliable performance measurement and analysis
 license:        BSD3
 license-file:   LICENSE


### PR DESCRIPTION
This fixes two things:

1. The current Hackage version of `criterion` is 1.1.4.0, but the repo is behind that. This brings the version in the repo up to date.
2. As noted in #126, the changelog doesn't mention 1.1.4.0, and moreover, the amount of changes that it _does_ mention is a bit lacking (for example, it didn't mention a change in the default template that resulted in #127). This PR attempts to mention more of the highlights of the 1.1.4.0 release.