### PR TITLE
Add new methods for allocating and cleaning up benchmark environments.

### DIFF
--- a/Criterion.hs
+++ b/Criterion.hs
@@ -17,6 +17,11 @@ module Criterion
     -- * Creating a benchmark suite
     , Benchmark
     , env
+    , envWithCleanup
+    , perBatchEnv
+    , perBatchEnvWithCleanup
+    , perRunEnv
+    , perRunEnvWithCleanup
     , bench
     , bgroup
     -- ** Running a benchmark

--- a/Criterion/Internal.hs
+++ b/Criterion/Internal.hs
@@ -22,16 +22,17 @@ import qualified Data.Aeson as Aeson
 import Control.DeepSeq (rnf)
 import Control.Exception (evaluate)
 import Control.Monad (foldM, forM_, void, when, unless)
+import Control.Monad.Catch (MonadMask, finally)
 import Control.Monad.Reader (ask, asks)
 import Control.Monad.Trans (MonadIO, liftIO)
 import Control.Monad.Trans.Except
-import qualified Data.Binary as Binary 
+import qualified Data.Binary as Binary
 import Data.Int (Int64)
 import qualified Data.ByteString.Lazy.Char8 as L
 import Criterion.Analysis (analyseSample, noteOutliers)
 import Criterion.IO (header, headerRoot, critVersion, readJSONReports, writeJSONReports)
 import Criterion.IO.Printf (note, printError, prolix, writeCsv)
-import Criterion.Measurement (runBenchmark, secs)
+import Criterion.Measurement (runBenchmark, runBenchmarkable_, secs)
 import Criterion.Monad (Criterion)
 import Criterion.Report (report)
 import Criterion.Types hiding (measure)
@@ -175,20 +176,20 @@ runFixedIters :: Int64            -- ^ Number of loop iterations to run.
 runFixedIters iters select bs =
   for select bs $ \_idx desc bm -> do
     _ <- note "benchmarking %s\n" desc
-    liftIO $ runRepeatedly bm iters
+    liftIO $ runBenchmarkable_ bm iters
 
 -- | Iterate over benchmarks.
-for :: MonadIO m => (String -> Bool) -> Benchmark
+for :: (MonadMask m, MonadIO m) => (String -> Bool) -> Benchmark
     -> (Int -> String -> Benchmarkable -> m ()) -> m ()
 for select bs0 handle = go (0::Int) ("", bs0) >> return ()
   where
-    go !idx (pfx, Environment mkenv mkbench)
+    go !idx (pfx, Environment mkenv cleanenv mkbench)
       | shouldRun pfx mkbench = do
         e <- liftIO $ do
           ee <- mkenv
           evaluate (rnf ee)
           return ee
-        go idx (pfx, mkbench e)
+        go idx (pfx, mkbench e) `finally` liftIO (cleanenv e)
       | otherwise = return idx
     go idx (pfx, Benchmark desc b)
       | select desc' = do handle idx desc' b; return $! idx + 1

--- a/Criterion/Main.hs
+++ b/Criterion/Main.hs
@@ -150,9 +150,9 @@ runMode wat bs =
   case wat of
     List -> mapM_ putStrLn . sort . concatMap benchNames $ bs
     Version -> putStrLn versionInfo
-    RunIters iters matchType benches -> do
+    RunIters cfg iters matchType benches -> do
       shouldRun <- selectBenches matchType benches bsgroup
-      withConfig defaultConfig $
+      withConfig cfg $
         runFixedIters iters shouldRun bsgroup
     Run cfg matchType benches -> do
       shouldRun <- selectBenches matchType benches bsgroup

--- a/Criterion/Main.hs
+++ b/Criterion/Main.hs
@@ -31,6 +31,11 @@ module Criterion.Main
     , Benchmark
     -- * Creating a benchmark suite
     , env
+    , envWithCleanup
+    , perBatchEnv
+    , perBatchEnvWithCleanup
+    , perRunEnv
+    , perRunEnvWithCleanup
     , bench
     , bgroup
     -- ** Running a benchmark

--- a/Criterion/Main/Options.hs
+++ b/Criterion/Main/Options.hs
@@ -57,7 +57,7 @@ data Mode = List
             -- ^ List all benchmarks.
           | Version
             -- ^ Print the version.
-          | RunIters Int64 MatchType [String]
+          | RunIters Config Int64 MatchType [String]
             -- ^ Run the given benchmarks, without collecting or
             -- analysing performance numbers.
           | Run Config MatchType [String]
@@ -93,7 +93,7 @@ parseWith cfg =
     (Version <$ switch (long "version" <> help "Show version info"))
   where
     runIters = matchNames $
-      RunIters <$> option auto
+      RunIters <$> config cfg <*> option auto
                   (long "iters" <> short 'n' <> metavar "ITERS" <>
                    help "Run benchmarks, don't analyse")
     matchNames wat = wat

--- a/Criterion/Measurement.hs
+++ b/Criterion/Measurement.hs
@@ -32,6 +32,7 @@ module Criterion.Measurement
     ) where
 
 import Criterion.Types (Benchmarkable(..), Measured(..))
+import Control.Applicative ((<*))
 import Control.DeepSeq (NFData(rnf))
 import Control.Exception (finally,evaluate)
 import Data.Int (Int64)

--- a/Criterion/Monad/Internal.hs
+++ b/Criterion/Monad/Internal.hs
@@ -18,8 +18,9 @@ module Criterion.Monad.Internal
     ) where
 
 -- Temporary: to support pre-AMP GHC 7.8.4:
-import Control.Applicative 
+import Control.Applicative
 
+import Control.Monad.Catch (MonadThrow, MonadCatch, MonadMask)
 import Control.Monad.Reader (MonadReader(..), ReaderT)
 import Control.Monad.Trans (MonadIO)
 import Criterion.Types (Config)
@@ -36,7 +37,7 @@ data Crit = Crit {
 -- | The monad in which most criterion code executes.
 newtype Criterion a = Criterion {
       runCriterion :: ReaderT Crit IO a
-    } deriving (Functor, Applicative, Monad, MonadIO)
+    } deriving (Functor, Applicative, Monad, MonadIO, MonadThrow, MonadCatch, MonadMask)
 
 instance MonadReader Config Criterion where
     ask     = config `fmap` Criterion ask

--- a/criterion.cabal
+++ b/criterion.cabal
@@ -173,6 +173,24 @@ test-suite tests
     vector,
     aeson >= 0.8
 
+test-suite cleanup
+  type:           exitcode-stdio-1.0
+  hs-source-dirs: tests
+  main-is:        Cleanup.hs
+
+  ghc-options:
+    -Wall -threaded -O0 -rtsopts -Wno-orphans
+
+  build-depends:
+    HUnit,
+    base,
+    bytestring,
+    criterion,
+    deepseq,
+    directory,
+    tasty,
+    tasty-hunit
+
 source-repository head
   type:     git
   location: https://github.com/bos/criterion.git

--- a/criterion.cabal
+++ b/criterion.cabal
@@ -83,7 +83,7 @@ library
     containers,
     deepseq >= 1.1.0.0,
     directory,
-    exceptions >= 0.8.3 && < 0.9,
+    exceptions >= 0.8.2 && < 0.9,
     filepath,
     Glob >= 0.7.2,
     hastache >= 0.6.0,
@@ -179,7 +179,7 @@ test-suite cleanup
   main-is:        Cleanup.hs
 
   ghc-options:
-    -Wall -threaded -O0 -rtsopts -Wno-orphans
+    -Wall -threaded -O0 -rtsopts
 
   build-depends:
     HUnit,

--- a/criterion.cabal
+++ b/criterion.cabal
@@ -83,6 +83,7 @@ library
     containers,
     deepseq >= 1.1.0.0,
     directory,
+    exceptions >= 0.8.3 && < 0.9,
     filepath,
     Glob >= 0.7.2,
     hastache >= 0.6.0,

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-6.1
+resolver: lts-6.31
 
 packages:
 - '.'

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,6 +3,7 @@ resolver: lts-6.31
 packages:
 - '.'
 
-extra-deps: []
+extra-deps:
+- optparse-applicative-0.13.2.0
 
 flags: {}

--- a/tests/Cleanup.hs
+++ b/tests/Cleanup.hs
@@ -1,0 +1,109 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+import Criterion.Main (Benchmark, bench, nfIO)
+import Criterion.Types (Config(..), Verbosity(Quiet))
+import Control.DeepSeq (NFData(..))
+import Control.Exception (Exception, try, throwIO)
+import Control.Monad (when)
+import Data.Typeable (Typeable)
+import System.Directory (doesFileExist, removeFile)
+import System.Environment (withArgs)
+import System.IO ( Handle, IOMode(ReadWriteMode), SeekMode(AbsoluteSeek)
+                 , hClose, hFileSize, hSeek, openFile)
+import Test.Tasty (TestTree, defaultMain, testGroup)
+import Test.Tasty.HUnit (testCase)
+import Test.HUnit (assertFailure)
+import qualified Criterion.Main as C
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+
+instance NFData Handle where
+    rnf !_ = ()
+
+data CheckResult = ShouldThrow | WrongData deriving (Show, Typeable)
+
+instance Exception CheckResult
+
+type BenchmarkWithFile =
+  String -> IO Handle -> (Handle -> IO ()) -> (Handle -> IO ()) -> Benchmark
+
+perRun :: BenchmarkWithFile
+perRun name alloc clean work =
+  bench name $ C.perRunEnvWithCleanup alloc clean work
+
+perBatch :: BenchmarkWithFile
+perBatch name alloc clean work =
+  bench name $ C.perBatchEnvWithCleanup (const alloc) (const clean) work
+
+envWithCleanup :: BenchmarkWithFile
+envWithCleanup name alloc clean work =
+  C.envWithCleanup alloc clean $ bench name . nfIO . work
+
+testCleanup :: Bool -> String -> BenchmarkWithFile -> TestTree
+testCleanup shouldFail name withEnvClean = testCase name $ do
+    existsBefore <- doesFileExist testFile
+    when existsBefore $ failTest "Input file already exists"
+
+    result <- runTest . withEnvClean name alloc clean $ \hnd -> do
+        result <- hFileSize hnd >>= BS.hGet hnd . fromIntegral
+        resetHandle hnd
+        when (result /= testData) $ throwIO WrongData
+        when shouldFail $ throwIO ShouldThrow
+
+    case result of
+        Left WrongData -> failTest "Incorrect result read from file"
+        Left ShouldThrow -> return ()
+        Right _ | shouldFail -> failTest "Failed to throw exception"
+                | otherwise -> return ()
+
+    existsAfter <- doesFileExist testFile
+    when existsAfter $ do
+        removeFile testFile
+        failTest "Failed to delete file"
+  where
+    testFile :: String
+    testFile = "tmp"
+
+    testData :: ByteString
+    testData = "blah"
+
+    runTest :: Benchmark -> IO (Either CheckResult ())
+    runTest = withArgs (["-n","1"]) . try . C.defaultMainWith config . pure
+      where
+        config = C.defaultConfig { verbosity = Quiet , timeLimit = 1 }
+
+    failTest :: String -> IO a
+    failTest s = assertFailure $ s ++ " in test: " ++ name ++ "!"
+
+    resetHandle :: Handle -> IO ()
+    resetHandle hnd = hSeek hnd AbsoluteSeek 0
+
+    alloc :: IO Handle
+    alloc = do
+        hnd <- openFile testFile ReadWriteMode
+        BS.hPut hnd testData
+        resetHandle hnd
+        return hnd
+
+    clean :: Handle -> IO ()
+    clean hnd = do
+        hClose hnd
+        removeFile testFile
+
+testSuccess :: String -> BenchmarkWithFile -> TestTree
+testSuccess = testCleanup False
+
+testFailure :: String -> BenchmarkWithFile -> TestTree
+testFailure = testCleanup True
+
+main :: IO ()
+main = defaultMain $ testGroup "cleanup"
+    [ testSuccess "perRun Success" perRun
+    , testFailure "perRun Failure" perRun
+    , testSuccess "perBatch Success" perBatch
+    , testFailure "perBatch Failure" perBatch
+    , testSuccess "envWithCleanup Success" envWithCleanup
+    , testFailure "envWithCleanup Failure" envWithCleanup
+    ]

--- a/tests/Cleanup.hs
+++ b/tests/Cleanup.hs
@@ -4,6 +4,7 @@
 
 import Criterion.Main (Benchmark, bench, nfIO)
 import Criterion.Types (Config(..), Verbosity(Quiet))
+import Control.Applicative (pure)
 import Control.DeepSeq (NFData(..))
 import Control.Exception (Exception, try, throwIO)
 import Control.Monad (when)

--- a/tests/Cleanup.hs
+++ b/tests/Cleanup.hs
@@ -74,7 +74,7 @@ testCleanup shouldFail name withEnvClean = testCase name $ do
       where
         config = C.defaultConfig { verbosity = Quiet , timeLimit = 1 }
 
-    failTest :: String -> IO a
+    failTest :: String -> IO ()
     failTest s = assertFailure $ s ++ " in test: " ++ name ++ "!"
 
     resetHandle :: Handle -> IO ()

--- a/tests/Cleanup.hs
+++ b/tests/Cleanup.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 


### PR DESCRIPTION
This patch adds support for per run benchmark allocation/cleanup of
environment, allocation/cleanup per batch of runs, and adds cleanup support for
the existing `env` function.

Fixes #79, #134, #135. Obsoletes #124.