### PR TITLE
Port to use statistics-0.14

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 dist
+dist-newstyle
 cabal.sandbox.config
 .cabal-sandbox
 *~

--- a/Criterion/Analysis.hs
+++ b/Criterion/Analysis.hs
@@ -50,7 +50,8 @@ import Statistics.Regression (bootstrapRegress, olsRegress)
 import Statistics.Resampling (resample)
 import Statistics.Sample (mean)
 import Statistics.Sample.KernelDensity (kde)
-import Statistics.Types (Estimator(..), Sample)
+import Statistics.Resampling (Estimator(..))
+import Statistics.Types (Sample)
 import System.Random.MWC (GenIO)
 import qualified Data.List as List
 import qualified Data.Map as Map
@@ -58,7 +59,10 @@ import qualified Data.Vector as V
 import qualified Data.Vector.Generic as G
 import qualified Data.Vector.Unboxed as U
 import qualified Statistics.Resampling.Bootstrap as B
+import qualified Statistics.Types as B
 import Prelude
+
+type Estimate = B.Estimate B.ConfInt Double
 
 -- | Classify outliers in a data set, using the boxplot technique.
 classifyOutliers :: Sample -> Outliers
@@ -81,8 +85,8 @@ classifyOutliers sa = U.foldl' ((. outlier) . mappend) mempty ssa
 
 -- | Compute the extent to which outliers in the sample data affect
 -- the sample mean and standard deviation.
-outlierVariance :: B.Estimate  -- ^ Bootstrap estimate of sample mean.
-                -> B.Estimate  -- ^ Bootstrap estimate of sample
+outlierVariance :: Estimate  -- ^ Bootstrap estimate of sample mean.
+                -> Estimate  -- ^ Bootstrap estimate of sample
                                --   standard deviation.
                 -> Double      -- ^ Number of original iterations.
                 -> OutlierVariance
@@ -160,7 +164,7 @@ analyseSample i name meas = do
   rs <- mapM (\(ps,r) -> regress gen ps r meas) $
         ((["iters"],"time"):regressions)
   resamps <- liftIO $ resample gen ests resamples stime
-  let [estMean,estStdDev] = B.bootstrapBCA confInterval stime ests resamps
+  let [estMean,estStdDev] = B.bootstrapBCA confInterval stime resamps
       ov = outlierVariance estMean estStdDev (fromIntegral n)
       an = SampleAnalysis {
                anRegress    = rs

--- a/Criterion/Main/Options.hs
+++ b/Criterion/Main/Options.hs
@@ -39,6 +39,7 @@ import Options.Applicative.Help (Chunk(..), tabulate)
 import Options.Applicative.Help.Pretty ((.$.))
 import Options.Applicative.Types
 import Paths_criterion (version)
+import Statistics.Types (mkCL, cl95)
 import Text.PrettyPrint.ANSI.Leijen (Doc, text)
 import qualified Data.Map as M
 import Prelude
@@ -67,7 +68,7 @@ data Mode = List
 -- | Default benchmarking configuration.
 defaultConfig :: Config
 defaultConfig = Config {
-      confInterval = 0.95
+      confInterval = cl95
     , forceGC      = True
     , timeLimit    = 5
     , resamples    = 1000
@@ -104,7 +105,7 @@ parseWith cfg =
 
 config :: Config -> Parser Config
 config Config{..} = Config
-  <$> option (range 0.001 0.999)
+  <$> option (range (mkCL 0.001) (mkCL 0.999))
       (long "ci" <> short 'I' <> metavar "CI" <> value confInterval <>
        help "Confidence interval")
   <*> (not <$> switch (long "no-gc" <> short 'G' <>

--- a/Criterion/Types.hs
+++ b/Criterion/Types.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE Trustworthy #-}
 {-# LANGUAGE DeriveDataTypeable, DeriveGeneric, GADTs, RecordWildCards #-}
 {-# OPTIONS_GHC -funbox-strict-fields #-}
@@ -78,8 +79,13 @@ import Data.Map (Map, fromList)
 import GHC.Generics (Generic)
 import qualified Data.Vector as V
 import qualified Data.Vector.Unboxed as U
-import qualified Statistics.Resampling.Bootstrap as B
+import qualified Statistics.Types as B
 import Prelude
+
+import Data.Vector.Binary ()
+
+type Estimate = B.Estimate B.ConfInt Double
+
 
 -- | Control the amount of information displayed.
 data Verbosity = Quiet
@@ -90,7 +96,7 @@ data Verbosity = Quiet
 
 -- | Top-level benchmarking configuration.
 data Config = Config {
-      confInterval :: Double
+      confInterval :: B.CL Double
       -- ^ Confidence interval for bootstrap estimation (greater than
       -- 0, less than 1).
     , forceGC      :: Bool
@@ -551,9 +557,9 @@ instance NFData OutlierVariance where
 data Regression = Regression {
     regResponder  :: String
     -- ^ Name of the responding variable.
-  , regCoeffs     :: Map String B.Estimate
+  , regCoeffs     :: Map String Estimate
     -- ^ Map from name to value of predictor coefficients.
-  , regRSquare    :: B.Estimate
+  , regRSquare    :: Estimate
     -- ^ R&#0178; goodness-of-fit estimate.
   } deriving (Eq, Read, Show, Typeable, Data, Generic)
 
@@ -576,9 +582,9 @@ data SampleAnalysis = SampleAnalysis {
     , anOverhead   :: Double
       -- ^ Estimated measurement overhead, in seconds.  Estimation is
       -- performed via linear regression.
-    , anMean       :: B.Estimate
+    , anMean       :: Estimate
       -- ^ Estimated mean.
-    , anStdDev     :: B.Estimate
+    , anStdDev     :: Estimate
       -- ^ Estimated standard deviation.
     , anOutlierVar :: OutlierVariance
       -- ^ Description of the effects of outliers on the estimated

--- a/criterion.cabal
+++ b/criterion.cabal
@@ -92,13 +92,14 @@ library
     mwc-random >= 0.8.0.3,
     optparse-applicative >= 0.13,
     parsec >= 3.1.0,
-    statistics >= 0.13.2.1,
+    statistics >= 0.14.0.1,
     text >= 0.11,
     time,
     transformers,
     transformers-compat >= 0.4,
     vector >= 0.7.1,
-    vector-algorithms >= 0.4
+    vector-algorithms >= 0.4,
+    vector-binary-instances >= 0.2.3.5
   if impl(ghc < 7.6)
     build-depends:
       ghc-prim


### PR DESCRIPTION
Works for GHC >= 7.8

On older GHC it won't as `Estimate` isn't `Data` anymore (cascading so that about everything isn't, yet is still `Generic`). There are three options

- Check if `Data` instances can be derived by hand in `statistics`
- Workaround `Data` requirement in [`mkGenericContext`](https://www.stackage.org/haddock/lts-8.14/hastache-0.6.1/Text-Hastache-Context.html)
- Drop support for GHC < 7.8 (that would be pity)
- Rewrite report generation using `blaze-markup` or `lucid` (but then we'll loose templating option. Is it used?)

comments?