### PR TITLE
Fix #146 by introducing GCStatistics

### DIFF
--- a/Criterion/Measurement.hs
+++ b/Criterion/Measurement.hs
@@ -110,18 +110,6 @@ data GCStatistics = GCStatistics
     , gcStatsCpuSeconds :: !Double
     -- | Total wall clock time elapsed since start
     , gcStatsWallSeconds :: !Double
-    -- | Number of bytes copied during GC, minus space held by mutable
-    -- lists held by the capabilities.  Can be used with
-    -- 'gcStatsParMaxBytesCopied' to determine how well parallel GC utilized
-    -- all cores.
-    , gcStatsParTotBytesCopied :: !Int64
-
-    -- | Sum of number of bytes copied each GC by the most active GC
-    -- thread each GC.  The ratio of 'gcStatsParTotBytesCopied' divided by
-    -- 'gcStatsParMaxBytesCopied' approaches 1 for a maximally sequential
-    -- run and approaches the number of threads (set by the RTS flag
-    -- @-N@) for a maximally parallel run.
-    , gcStatsParMaxBytesCopied :: !Int64
     } deriving (Eq, Read, Show, Typeable, Data, Generic)
 
 -- | Try to get GC statistics, bearing in mind that the GHC runtime
@@ -167,8 +155,6 @@ getGCStatistics = do
     , gcStatsGcWallSeconds          = nsToSecs $ gcdetails_elapsed_ns gcdetails
     , gcStatsCpuSeconds             = nsToSecs $ cpu_ns stats
     , gcStatsWallSeconds            = nsToSecs $ elapsed_ns stats
-    , gcStatsParTotBytesCopied      = fromIntegral $ par_copied_bytes stats
-    , gcStatsParMaxBytesCopied      = fromIntegral $ cumulative_par_max_copied_bytes stats
     }
  `Exc.catch`
   \(_::Exc.SomeException) -> return Nothing
@@ -193,8 +179,6 @@ getGCStatistics = do
     , gcStatsGcWallSeconds          = gcWallSeconds stats
     , gcStatsCpuSeconds             = cpuSeconds stats
     , gcStatsWallSeconds            = wallSeconds stats
-    , gcStatsParTotBytesCopied      = parTotBytesCopied stats
-    , gcStatsParMaxBytesCopied      = parMaxBytesCopied stats
     }
  `Exc.catch`
   \(_::Exc.SomeException) -> return Nothing

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+next
+
+* Add `GCStatistics`, `getGCStatistics`, and `applyGCStatistics` to
+  `Criterion.Measurement`. These are inteded to replace `GCStats` (which has
+  been deprecated in `base` and will be removed in GHC 8.4), as well as
+  `getGCStats` and `applyGCStats`, which have also been deprecated and will be
+  removed in the next major `criterion` release.
+
 1.2.0.0
 
 * Use `statistics-0.14`.

--- a/examples/Overhead.hs
+++ b/examples/Overhead.hs
@@ -11,18 +11,27 @@ import GHC.Stats as GHC
 
 main :: IO ()
 main = do
-  statsEnabled <- getGCStatsEnabled
+  statsEnabled <- getRTSStatsEnabled
   defaultMain $ [
-      bench "measure" $      whnfIO (M.measure (whnfIO $ return ()) 1)
-    , bench "getTime" $      whnfIO M.getTime
-    , bench "getCPUTime" $   whnfIO M.getCPUTime
-    , bench "getCycles" $    whnfIO M.getCycles
-    , bench "M.getGCStats" $ whnfIO M.getGCStats
+      bench "measure" $            whnfIO (M.measure (whnfIO $ return ()) 1)
+    , bench "getTime" $            whnfIO M.getTime
+    , bench "getCPUTime" $         whnfIO M.getCPUTime
+    , bench "getCycles" $          whnfIO M.getCycles
+    , bench "M.getGCStatisticss" $ whnfIO M.getGCStatistics
     ] ++ if statsEnabled
-         then [bench "GHC.getGCStats" $ whnfIO GHC.getGCStats]
+         then [bench
+#if MIN_VERSION_base(4,10,0)
+                     "GHC.getRTSStats" $ whnfIO GHC.getRTSStats
+#else
+                     "GHC.getGCStats" $  whnfIO GHC.getGCStats
+#endif
+              ]
          else []
 
 #if !MIN_VERSION_base(4,6,0)
-getGCStatsEnabled :: IO Bool
-getGCStatsEnabled = return False
+getRTSStatsEnabled :: IO Bool
+getRTSStatsEnabled = return False
+#elif !MIN_VERSION_base(4,10,0)
+getRTSStatsEnabled :: IO Bool
+getRTSStatsEnabled = getGCStatsEnabled
 #endif


### PR DESCRIPTION
This introduces a backwards-compatible `GCStatistics` type, as well as functions supporting it, intended to replace the now-deprecated `GCStats` interface.

Fixes #146.