### PR TITLE
Emit mustache template warnings

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+next
+
+* Have `criterion` emit warnings if suspicious things happen during mustache
+  template substitution when creating HTML reports. This can be useful when
+  using custom templates with the `--template` flag.
+
 1.2.1.0
 
 * Add `GCStatistics`, `getGCStatistics`, and `applyGCStatistics` to

--- a/criterion.cabal
+++ b/criterion.cabal
@@ -94,7 +94,7 @@ library
     exceptions >= 0.8.2 && < 0.9,
     filepath,
     Glob >= 0.7.2,
-    microstache >= 1 && < 1.1,
+    microstache >= 1.0.1 && < 1.1,
     js-flot,
     js-jquery,
     mtl >= 2,


### PR DESCRIPTION
Previously, if you passed in a custom mustache template via `--template` and it failed to substitute in a variable correctly, `criterion` would silently ignore it. This PR leverages new features in `microstache` to make the failure more explicit. For instance, if you have a template that tries to substitute in `{{{jsonx}}}` instead of `{{{json}}}`, it will now emit this warning:

```
criterion: warning:
  Referenced value was not provided, key: jsonx
```

Fixes #127.