### PR TITLE
Add Semigroup instance for Outliers

### DIFF
--- a/Criterion/Types.hs
+++ b/Criterion/Types.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE Trustworthy #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE DeriveDataTypeable, DeriveGeneric, GADTs, RecordWildCards #-}
@@ -74,6 +75,7 @@ module Criterion.Types
 -- Temporary: to support pre-AMP GHC 7.8.4:
 import Control.Applicative
 import Data.Monoid
+import Data.Semigroup
 
 import Control.DeepSeq (NFData(rnf))
 import Control.Exception (evaluate)
@@ -660,9 +662,14 @@ instance Binary OutlierEffect where
             _ -> fail $ "get for OutlierEffect: unexpected " ++ show i
 instance NFData OutlierEffect
 
+instance Semigroup Outliers where
+    (<>) = addOutliers
+
 instance Monoid Outliers where
     mempty  = Outliers 0 0 0 0 0
+#if !(MIN_VERSION_base(4,11,0))
     mappend = addOutliers
+#endif
 
 addOutliers :: Outliers -> Outliers -> Outliers
 addOutliers (Outliers s a b c d) (Outliers t w x y z) =

--- a/criterion.cabal
+++ b/criterion.cabal
@@ -101,6 +101,7 @@ library
     mwc-random >= 0.8.0.3,
     optparse-applicative >= 0.13,
     parsec >= 3.1.0,
+    semigroups,
     statistics >= 0.14 && < 0.15,
     text >= 0.11,
     time,


### PR DESCRIPTION
This will be needed in GHC 8.4 due to the Semigroup/Monoid proposal.