### PR TITLE
Resolve #45 by adding an -fembed-data-files flag 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ matrix:
     - compiler: "ghc-8.2.2"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.2.2], sources: [hvr-ghc]}}
-    - compiler: "ghc-8.2.2 (-fembed-data-files)"
+    - compiler: "ghc-8.2.2"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
       env: CABALFLAGS=--ghc-option=-fembed-data-files
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.2.2], sources: [hvr-ghc]}}

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ matrix:
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.2.2], sources: [hvr-ghc]}}
     - compiler: "ghc-8.2.2"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
-      env: CABALFLAGS=--ghc-option=-fembed-data-files
+      env: CABALFLAGS=-fembed-data-files
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.2.2], sources: [hvr-ghc]}}
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,8 +44,9 @@ matrix:
     - compiler: "ghc-8.2.2"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.2.2], sources: [hvr-ghc]}}
-    - compiler: "ghc-8.2.2"
-    # env: TEST=--disable-tests BENCH=--disable-benchmarks CABALFLAGS=-fembed-data-files
+    - compiler: "ghc-8.2.2 (-fembed-data-files)"
+    # env: TEST=--disable-tests BENCH=--disable-benchmarks
+      env: CABALFLAGS=-fembed-data-files
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.2.2], sources: [hvr-ghc]}}
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,9 @@ matrix:
     - compiler: "ghc-8.2.2"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.2.2], sources: [hvr-ghc]}}
+    - compiler: "ghc-8.2.2"
+    # env: TEST=--disable-tests BENCH=--disable-benchmarks CABALFLAGS=-fembed-data-files
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.2.2], sources: [hvr-ghc]}}
 
 before_install:
  - HC=${CC}
@@ -61,8 +64,8 @@ install:
  - rm -fv cabal.project.local
  - "echo 'packages: .' > cabal.project"
  - rm -f cabal.project.freeze
- - cabal new-build -w ${HC} ${TEST} ${BENCH} --dep -j2 all
- - cabal new-build -w ${HC} --disable-tests --disable-benchmarks --dep -j2 all
+ - cabal new-build -w ${HC} ${CABALFLAGS} ${TEST} ${BENCH} --dep -j2 all
+ - cabal new-build -w ${HC} ${CABALFLAGS} --disable-tests --disable-benchmarks --dep -j2 all
 
 # Here starts the actual work to be performed for the package under test;
 # any command which exits with a non-zero exit code causes the build to fail.
@@ -80,13 +83,13 @@ script:
  - "echo 'packages: .' > cabal.project"
  # this builds all libraries and executables (without tests/benchmarks)
  - rm -f cabal.project.freeze
- - cabal new-build -w ${HC} --disable-tests --disable-benchmarks all
+ - cabal new-build -w ${HC} ${CABALFLAGS} --disable-tests --disable-benchmarks all
  # this builds all libraries and executables (including tests/benchmarks)
  # - rm -rf ./dist-newstyle
 
  # build & run tests
- - cabal new-build -w ${HC} ${TEST} ${BENCH} all
- - if [ "x$TEST" = "x--enable-tests" ]; then cabal new-test -w ${HC} ${TEST} all; fi
+ - cabal new-build -w ${HC} ${CABALFLAGS} ${TEST} ${BENCH} all
+ - if [ "x$TEST" = "x--enable-tests" ]; then cabal new-test -w ${HC} ${CABALFLAGS} ${TEST} all; fi
 
 # EOF
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ matrix:
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.2.2], sources: [hvr-ghc]}}
     - compiler: "ghc-8.2.2 (-fembed-data-files)"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
-      env: CABALFLAGS=-fembed-data-files
+      env: CABALFLAGS=--ghc-option=-fembed-data-files
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.2.2], sources: [hvr-ghc]}}
 
 before_install:

--- a/Criterion/EmbeddedData.hs
+++ b/Criterion/EmbeddedData.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+-- |
+-- Module      : Criterion.EmbeddedData
+-- Copyright   : (c) 2017 Ryan Scott
+--
+-- License     : BSD-style
+-- Maintainer  : bos@serpentine.com
+-- Stability   : experimental
+-- Portability : GHC
+--
+-- When the @embed-data-files@ @Cabal@ flag is enabled, this module exports
+-- the contents of various files (the @data-files@ from @criterion.cabal@, as
+-- well as minimized versions of jQuery and Flot) embedded as 'ByteString's.
+module Criterion.EmbeddedData (dataFiles, jQueryContents, flotContents) where
+
+import Data.ByteString (ByteString)
+import Data.FileEmbed (embedDir, embedFile)
+import Language.Haskell.TH.Syntax (runIO)
+import qualified Language.Javascript.Flot as Flot
+import qualified Language.Javascript.JQuery as JQuery
+
+dataFiles :: [(FilePath, ByteString)]
+dataFiles = $(embedDir "templates")
+
+jQueryContents, flotContents :: ByteString
+jQueryContents = $(embedFile =<< runIO JQuery.file)
+flotContents   = $(embedFile =<< runIO (Flot.file Flot.Flot))

--- a/Criterion/Report.hs
+++ b/Criterion/Report.hs
@@ -97,16 +97,20 @@ formatReport reports templateName = do
 
     jQuery <- T.readFile =<< JQuery.file
     flot <- T.readFile =<< Flot.file Flot.Flot
+    jQueryCriterionJS <- T.readFile =<< getDataFileName "templates/js/jquery.criterion.js"
+    criterionCSS <- T.readFile =<< getDataFileName "templates/criterion.css"
 
     -- includes, only top level
     templates <- getTemplateDir
     template <- includeTemplate (includeFile [templates]) template0
 
     let context = object
-            [ "json"      .= reports
-            , "report"    .= map inner reports
-            , "js-jquery" .= jQuery
-            , "js-flot"   .= flot
+            [ "json"                .= reports
+            , "report"              .= map inner reports
+            , "js-jquery"           .= jQuery
+            , "js-flot"             .= flot
+            , "jquery-criterion-js" .= jQueryCriterionJS
+            , "criterion-css"       .= criterionCSS
             ]
 
     let (warnings, formatted) = renderMustacheW template context

--- a/criterion.cabal
+++ b/criterion.cabal
@@ -49,6 +49,12 @@ flag fast
   default: False
   manual: True
 
+flag embed-data-files
+  description: Embed the data files in the binary for a relocatable executable.
+               (Warning: This will increase the executable size significantly.)
+  default: False
+  manual: True
+
 library
   exposed-modules:
     Criterion
@@ -122,6 +128,12 @@ library
     ghc-options: -O0
   else
     ghc-options: -O2
+
+  if flag(embed-data-files)
+    other-modules: Criterion.EmbeddedData
+    build-depends: file-embed < 0.1,
+                   template-haskell
+    cpp-options: "-DEMBED"
 
 Executable criterion-report
   Default-Language:     Haskell2010

--- a/templates/default.tpl
+++ b/templates/default.tpl
@@ -10,10 +10,10 @@
       {{{js-flot}}}
     </script>
     <script language="javascript" type="text/javascript">
-      {{#include}}js/jquery.criterion.js{{/include}}
+      {{{jquery-criterion-js}}}
     </script>
     <style type="text/css">
-{{#include}}criterion.css{{/include}}
+      {{{criterion-css}}}
     </style>
     <!--[if !IE 7]>
 	    <style type="text/css">


### PR DESCRIPTION
This should make it simpler to create portable `criterion` binaries. Resolves #45.