### PR TITLE
Fix GC/RTS stats for base >= 4.10.0

### DIFF
--- a/Criterion/Measurement.hs
+++ b/Criterion/Measurement.hs
@@ -120,20 +120,20 @@ getGCStatistics = do
       nsToSecs ns = fromIntegral ns * 1.0E-9
 
   return $ Just GCStatistics {
-      gcStatsBytesAllocated         = fromIntegral $ gcdetails_allocated_bytes gcdetails
+      gcStatsBytesAllocated         = fromIntegral $ allocated_bytes stats
     , gcStatsNumGcs                 = fromIntegral $ gcs stats
     , gcStatsMaxBytesUsed           = fromIntegral $ max_live_bytes stats
     , gcStatsNumByteUsageSamples    = fromIntegral $ major_gcs stats
     , gcStatsCumulativeBytesUsed    = fromIntegral $ cumulative_live_bytes stats
-    , gcStatsBytesCopied            = fromIntegral $ gcdetails_copied_bytes gcdetails
+    , gcStatsBytesCopied            = fromIntegral $ copied_bytes stats
     , gcStatsCurrentBytesUsed       = fromIntegral $ gcdetails_live_bytes gcdetails
     , gcStatsCurrentBytesSlop       = fromIntegral $ gcdetails_slop_bytes gcdetails
     , gcStatsMaxBytesSlop           = fromIntegral $ max_slop_bytes stats
     , gcStatsPeakMegabytesAllocated = fromIntegral (max_mem_in_use_bytes stats) `quot` (1024*1024)
     , gcStatsMutatorCpuSeconds      = nsToSecs $ mutator_cpu_ns stats
     , gcStatsMutatorWallSeconds     = nsToSecs $ mutator_elapsed_ns stats
-    , gcStatsGcCpuSeconds           = nsToSecs $ gcdetails_cpu_ns gcdetails
-    , gcStatsGcWallSeconds          = nsToSecs $ gcdetails_elapsed_ns gcdetails
+    , gcStatsGcCpuSeconds           = nsToSecs $ cpu_ns stats
+    , gcStatsGcWallSeconds          = nsToSecs $ elapsed_ns stats
     , gcStatsCpuSeconds             = nsToSecs $ cpu_ns stats
     , gcStatsWallSeconds            = nsToSecs $ elapsed_ns stats
     }
@@ -175,10 +175,10 @@ measure bm iters = runBenchmarkable bm iters addResults $ \ !n act -> do
   startCpuTime <- getCPUTime
   startCycles <- getCycles
   act
+  endStats <- getGCStatistics
   endTime <- getTime
   endCpuTime <- getCPUTime
   endCycles <- getCycles
-  endStats <- getGCStatistics
   let !m = applyGCStatistics endStats startStats $ measured {
              measTime    = max 0 (endTime - startTime)
            , measCpuTime = max 0 (endCpuTime - startCpuTime)

--- a/Criterion/Measurement.hs
+++ b/Criterion/Measurement.hs
@@ -132,8 +132,8 @@ getGCStatistics = do
     , gcStatsPeakMegabytesAllocated = fromIntegral (max_mem_in_use_bytes stats) `quot` (1024*1024)
     , gcStatsMutatorCpuSeconds      = nsToSecs $ mutator_cpu_ns stats
     , gcStatsMutatorWallSeconds     = nsToSecs $ mutator_elapsed_ns stats
-    , gcStatsGcCpuSeconds           = nsToSecs $ cpu_ns stats
-    , gcStatsGcWallSeconds          = nsToSecs $ elapsed_ns stats
+    , gcStatsGcCpuSeconds           = nsToSecs $ gc_cpu_ns stats
+    , gcStatsGcWallSeconds          = nsToSecs $ gc_elapsed_ns stats
     , gcStatsCpuSeconds             = nsToSecs $ cpu_ns stats
     , gcStatsWallSeconds            = nsToSecs $ elapsed_ns stats
     }


### PR DESCRIPTION
From `GHC.Stats` documentation for `GCStats` in base 4.10.0.0 on [hackage](https://hackage.haskell.org/package/base-4.10.0.0/docs/GHC-Stats.html):

> Statistics about memory usage and the garbage collector. Apart from currentBytesUsed and currentBytesSlop all are cumulative values since the program started.

For base >= 4.10.0 criterion chooses to use the new `RTSStats` type for GC measurements, but uses `GCDetails` for bytes allocated, bytes copied, and GC CPU times. This gave bogus results when, for instance, regressing allocated over iters. This program:

```Haskell
import Data.ByteString (ByteString)
import qualified Data.ByteString as BS
import Criterion
import Criterion.Main

makeBS :: Int -> ByteString
makeBS n = BS.replicate n 0

benchmarks :: [Benchmark]
benchmarks = [
    bench "make" (nf makeBS 1024)
  ]

main :: IO ()
main = defaultMain benchmarks
```

would show

```
allocated:           0.110 R²   (0.083 R² .. 0.145 R²)
  iters              0.414      (0.329 .. 0.539)
  y                  474831.157 (419995.999 .. 527923.352)
```

because the `GCDetails` gives "Details about the most recent GC".

With this patch the above program gives

```
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              1231.941   (1231.790 .. 1232.058)
  y                  -307784.572 (-341986.905 .. -274514.542)
```