### PR TITLE
Fix per-run combine time (fixes #181)

### DIFF
--- a/Criterion/Measurement.hs
+++ b/Criterion/Measurement.hs
@@ -197,7 +197,7 @@ measure bm iters = runBenchmarkable bm iters addResults $ \ !n act -> do
   return (m, endTime)
   where
     addResults :: (Measured, Double) -> (Measured, Double) -> (Measured, Double)
-    addResults (!m1, !d1) (!m2, !d2) = (m3, d1 + d2)
+    addResults (!m1, _) (!m2, !d2) = (m3, d2)
       where
         add f = f m1 + f m2
 

--- a/Criterion/Measurement.hs
+++ b/Criterion/Measurement.hs
@@ -196,6 +196,8 @@ measure bm iters = runBenchmarkable bm iters addResults $ \ !n act -> do
            }
   return (m, endTime)
   where
+    -- When combining runs, the Measured value is accumulated over many runs,
+    -- but the Double value is the most recent absolute measurement of time.
     addResults :: (Measured, Double) -> (Measured, Double) -> (Measured, Double)
     addResults (!m1, _) (!m2, !d2) = (m3, d2)
       where

--- a/changelog.md
+++ b/changelog.md
@@ -35,6 +35,9 @@
   causing runtime errors and invalid results. Accordingly, the buggy
   `getOverhead` function has been removed.
 
+* Fix a bug in `Measurement.measure` which inflated the reported time taken
+  for `perRun` benchmarks.
+
 1.3.0.0
 
 * `criterion` was previously reporting the following statistics incorrectly


### PR DESCRIPTION
Before change:

    benchmarking perRun
    measurement took 231495 s (60 hours!!!)
    analysing with 1000 resamples
    bootstrapping with 13 of 22 samples (59%)
    time                 3.112 ms   (3.102 ms .. 3.122 ms)
                         1.000 R²   (1.000 R² .. 1.000 R²)
    mean                 3.119 ms   (3.111 ms .. 3.122 ms)
    std dev              10.00 μs   (5.617 μs .. 16.74 μs)
    found 1 outliers among 13 samples (7.7%)
      1 (7.7%) low severe
    variance introduced by outliers: 4% (slightly inflated)

After:

    benchmarking perRun
    measurement took 5.135 s
    analysing with 1000 resamples
    bootstrapping with 33 of 42 samples (78%)
    time                 3.120 ms   (3.116 ms .. 3.124 ms)
                         1.000 R²   (1.000 R² .. 1.000 R²)
    mean                 3.117 ms   (3.111 ms .. 3.120 ms)
    std dev              11.95 μs   (6.974 μs .. 20.56 μs)
    found 3 outliers among 33 samples (9.1%)
      3 (9.1%) low severe
    variance introduced by outliers: 2% (slightly inflated)

The reported time is now much more accurate, and we get double the number samples.
