### PR TITLE
Remove allocation from inner loops (fixes #183)

### DIFF
--- a/Criterion/Types.hs
+++ b/Criterion/Types.hs
@@ -76,7 +76,6 @@ module Criterion.Types
 import Data.Semigroup
 
 import Control.DeepSeq (NFData(rnf))
-import Control.Exception (evaluate)
 import Criterion.Types.Internal (fakeEnvironment, nf', whnf')
 import Data.Aeson (FromJSON(..), ToJSON(..))
 import Data.Binary (Binary(..), putWord8, getWord8)

--- a/Criterion/Types.hs
+++ b/Criterion/Types.hs
@@ -349,9 +349,10 @@ whnfIO' :: IO a -> Int64 -> IO ()
 whnfIO' a = go
   where
     go n | n <= 0    = return ()
-         | otherwise = evaluate a >> go (n-1)
+         | otherwise = do
+             x <- a
+             evaluate x >> go (n-1)
 {-# NOINLINE whnfIO' #-}
-
 
 -- | Specification of a collection of benchmarks and environments. A
 -- benchmark may consist of:

--- a/Criterion/Types.hs
+++ b/Criterion/Types.hs
@@ -57,8 +57,8 @@ module Criterion.Types
     , addPrefix
     , benchNames
     -- ** Evaluation control
-    , whnf
     , nf
+    , whnf
     , nfIO
     , whnfIO
     -- * Result types

--- a/Criterion/Types.hs
+++ b/Criterion/Types.hs
@@ -336,7 +336,15 @@ whnfIO a = toBenchmarkable (whnfIO' a)
 
 -- Along with nf' and whnf', the following two functions are the core
 -- benchmarking loops. They have been carefully constructed to avoid
--- allocation while also evaluating 'a'. See #183 and #184 for discussion.
+-- allocation while also evaluating @a@.
+--
+-- These functions must not be inlined. There are two possible issues that
+-- can arise if they are inlined. First, the work is often floated out of
+-- the loop, which creates a nonsense benchmark. Second, the benchmark code
+-- itself could be changed by the user's optimization level. By marking them
+-- @NOINLINE@, the core benchmark code is always the same.
+--
+-- See #183 and #184 for discussion.
 
 -- | Generate a function that will run an action a given number of times,
 -- reducing it to normal form each time.

--- a/Criterion/Types.hs
+++ b/Criterion/Types.hs
@@ -329,7 +329,8 @@ pureFunc :: (b -> c) -> (a -> b) -> a -> Benchmarkable
 pureFunc reduce f0 x0 = toBenchmarkable (go f0 x0)
   where go f x n
           | n <= 0    = return ()
-          | otherwise = evaluate (reduce (f x)) >> go f x (n-1)
+          | otherwise = let !y = reduce (f x)
+                        in evaluate y >> go f x (n-1)
 {-# INLINE pureFunc #-}
 
 -- | Perform an action, then evaluate its result to normal form.

--- a/Criterion/Types.hs
+++ b/Criterion/Types.hs
@@ -341,8 +341,7 @@ nfIO' reduce a = go
           | n <= 0    = return ()
           | otherwise = do
               x <- a
-              let !y = reduce x
-              evaluate y >> go (n-1)
+              reduce x `seq` go (n-1)
 {-# NOINLINE nfIO' #-}
 
 whnfIO' :: IO a -> Int64 -> IO ()
@@ -351,7 +350,7 @@ whnfIO' a = go
     go n | n <= 0    = return ()
          | otherwise = do
              x <- a
-             evaluate x >> go (n-1)
+             x `seq` go (n-1)
 {-# NOINLINE whnfIO' #-}
 
 -- | Specification of a collection of benchmarks and environments. A

--- a/Criterion/Types/Internal.hs
+++ b/Criterion/Types/Internal.hs
@@ -26,11 +26,17 @@ fakeEnvironment = error $ unlines
 
 -- Along with Criterion.Types.nfIO' and Criterion.Types.whnfIO', the following
 -- two functions are the core benchmarking loops. They have been carefully
--- constructed to avoid allocation while also evaluating 'f x'.
+-- constructed to avoid allocation while also evaluating @f x@.
 --
--- Because these functions are pure, GHC is particularly smart about
--- optimizing them. We must turn of `-ffull-laziness` to prevent the
--- computation from being floated out of the loop.
+-- Because these functions are pure, GHC is particularly smart about optimizing
+-- them. We must turn off @-ffull-laziness@ to prevent the computation from
+-- being floated out of the loop.
+--
+-- For a similar reason, these functions must not be inlined. There are two
+-- possible issues that can arise if they are inlined. First, the work is often
+-- floated out of the loop, which creates a nonsense benchmark. Second, the
+-- benchmark code itself could be changed by the user's optimization level. By
+-- marking them @NOINLINE@, the core benchmark code is always the same.
 --
 -- See #183 and #184 for discussion.
 

--- a/Criterion/Types/Internal.hs
+++ b/Criterion/Types/Internal.hs
@@ -24,7 +24,17 @@ fakeEnvironment = error $ unlines
   , "\t(see the documentation for `env` for details)"
   ]
 
--- | Return a function which applies an argument to a function a
+-- Along with Criterion.Types.nfIO' and Criterion.Types.whnfIO', the following
+-- two functions are the core benchmarking loops. They have been carefully
+-- constructed to avoid allocation while also evaluating 'f x'.
+--
+-- Because these functions are pure, GHC is particularly smart about
+-- optimizing them. We must turn of `-ffull-laziness` to prevent the
+-- computation from being floated out of the loop.
+--
+-- See #183 and #184 for discussion.
+
+-- | Generate a function which applies an argument to a function a
 -- given number of times, reducing the result to normal form.
 nf' :: (b -> ()) -> (a -> b) -> a -> (Int64 -> IO ())
 nf' reduce f x = go
@@ -34,7 +44,7 @@ nf' reduce f x = go
                        in reduce y `seq` go (n-1)
 {-# NOINLINE nf' #-}
 
--- | Return a function which applies an argument to a function a
+-- | Generate a function which applies an argument to a function a
 -- given number of times.
 whnf' :: (a -> b) -> a -> (Int64 -> IO ())
 whnf' f x = go

--- a/Criterion/Types/Internal.hs
+++ b/Criterion/Types/Internal.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -fno-full-laziness #-}
 -- |
 -- Module      : Criterion.Types.Internal
 -- Copyright   : (c) 2017 Ryan Scott
@@ -8,7 +9,9 @@
 -- Portability : GHC
 --
 -- Exports 'fakeEnvironment'.
-module Criterion.Types.Internal (fakeEnvironment) where
+module Criterion.Types.Internal (fakeEnvironment, nf', whnf') where
+
+import Data.Int (Int64)
 
 -- | A dummy environment that is passed to functions that create benchmarks
 -- from environments when no concrete environment is available.
@@ -19,3 +22,22 @@ fakeEnvironment = error $ unlines
   , "\tconstructs benchmarks from an environment?"
   , "\t(see the documentation for `env` for details)"
   ]
+
+-- | Return a function which applies an argument to a function a
+-- given number of times, reducing the result to normal form.
+nf' :: (b -> ()) -> (a -> b) -> a -> (Int64 -> IO ())
+nf' reduce f x = go
+  where
+    go n | n <= 0    = return ()
+         | otherwise = let !y = f x
+                       in reduce y `seq` go (n-1)
+{-# NOINLINE nf' #-}
+
+-- | Return a function which applies an argument to a function a
+-- given number of times.
+whnf' :: (a -> b) -> a -> (Int64 -> IO ())
+whnf' f x = go
+  where
+    go n | n <= 0    = return ()
+         | otherwise = f x `seq` go (n-1)
+{-# NOINLINE whnf' #-}

--- a/Criterion/Types/Internal.hs
+++ b/Criterion/Types/Internal.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 {-# OPTIONS_GHC -fno-full-laziness #-}
 -- |
 -- Module      : Criterion.Types.Internal

--- a/changelog.md
+++ b/changelog.md
@@ -38,6 +38,9 @@
 * Fix a bug in `Measurement.measure` which inflated the reported time taken
   for `perRun` benchmarks.
 
+* Reduce overhead of `nf`, `whnf`, `nfIO`, and `whnfIO` by removing allocation
+  from the central loops.
+
 1.3.0.0
 
 * `criterion` was previously reporting the following statistics incorrectly


### PR DESCRIPTION
This is finished in theory, but will need to be documented/cleaned up for merge.

It can be tested with my development wrapper [here](https://github.com/patrickdoc/criterion-bug). You can clone, pull the crriterion submodule, and use `run-versions.sh` to run `example/Small.hs` under various optimizations. I've attached output from my computer to save time though.

[comparison.txt](https://github.com/bos/criterion/files/1697880/comparison.txt)

# Wins

The biggest highlight is this comparison:

```
-- Old with -O2
17,911,308,968 bytes allocated in the heap

-- New with -O2
   293,624,648 bytes allocated in the heap
```

This does have an impact on measured times. For instance, `whnf id x` drops to ~6ns from ~9ns.

The checklist looks like so:

- [x] Apply `f` to `x` on every iteration
- [x] Do not allocate the result of `f x`
- [x] Eliminate the `id` from `whnf`
- [ ] *Possibly inline `rnf` in `nf`
- [x] Maintain all of these regardless of optimization from the user
- [x] Should not be broken by `-fstatic-argument-transformation`

Most of these problems are fixed by small tweaks and `NOINLINE` pragmas. These functions are all intentionally non-optimal, and GHC is very eager to optimize out the work. `NOINLINE` is the simplest way to avoid that in most cases, and we don't lose anything with it. It also completely eliminates worries about optimizations on the user's part, and lets them test optimized vs. non-optimized code without the benchmark code changing.

The pure functions, `nf` and `whnf`, required more drastic measures. They have been moved to `Criterion/Types/Internal.hs` which has gained an `-fno-full-laziness` option. This is somewhat heavy handed, but GHC really does not want to do any work :P This was the only way I found that could both make the function application strict (avoiding allocation) and not float out the computation.

Because of the `NOINLINE` pragmas, `rnf` will never be inlined. I think that should be ok though, because `rnf` is already adding in a fair bit of overhead that we can't account for anyway.

# Details

The source was mostly guided by the dumped stg, so here are the functions:

```
-- nf
nf'1 =
    \r [reduce_s3Aq f_s3Ar x_s3As eta_s3At void_0E]
        case eta_s3At of {
          I64# ww1_s3Aw ->
              let-no-escape {
                $wgo_s3Ax =
                    sat-only \r [ww2_s3Ay void_0E]
                        case <=# [ww2_s3Ay 0#] of sat_s3AA {
                          __DEFAULT ->
                              case tagToEnum# [sat_s3AA] of {
                                False ->
                                    case f_s3Ar x_s3As of y_s3AC {
                                      __DEFAULT ->
                                          case reduce_s3Aq y_s3AC of {
                                            () ->
                                                case -# [ww2_s3Ay 1#] of sat_s3AE {
                                                  __DEFAULT -> $wgo_s3Ax sat_s3AE void#;
                                                };
                                          };
                                    };
                                True -> Unit# [()];
                              };
                        };
              } in  $wgo_s3Ax ww1_s3Aw void#;
        };

-- whnf
whnf'1 =
    \r [f_s3AF x_s3AG eta_s3AH void_0E]
        case eta_s3AH of {
          I64# ww1_s3AK ->
              let-no-escape {
                $wgo_s3AL =
                    sat-only \r [ww2_s3AM void_0E]
                        case <=# [ww2_s3AM 0#] of sat_s3AO {
                          __DEFAULT ->
                              case tagToEnum# [sat_s3AO] of {
                                False ->
                                    case f_s3AF x_s3AG of {
                                      __DEFAULT ->
                                          case -# [ww2_s3AM 1#] of sat_s3AR {
                                            __DEFAULT -> $wgo_s3AL sat_s3AR void#;
                                          };
                                    };
                                True -> Unit# [()];
                              };
                        };
              } in  $wgo_s3AL ww1_s3AK void#;
        };


-- nfIO
nfIO1 =
    \r [reduce_s2otr a1_s2ots eta_s2ott void_0E]
        case eta_s2ott of {
          I64# ww1_s2otw ->
              let-no-escape {
                $wgo11_s2otx =
                    sat-only \r [ww2_s2oty void_0E]
                        case <=# [ww2_s2oty 0#] of sat_s2otA {
                          __DEFAULT ->
                              case tagToEnum# [sat_s2otA] of {
                                False ->
                                    case a1_s2ots void# of {
                                      Unit# ipv3_s2otE ->
                                          case reduce_s2otr ipv3_s2otE of {
                                            __DEFAULT ->
                                                case -# [ww2_s2oty 1#] of sat_s2otG {
                                                  __DEFAULT -> $wgo11_s2otx sat_s2otG void#;
                                                };
                                          };
                                    };
                                True -> Unit# [()];
                              };
                        };
              } in  $wgo11_s2otx ww1_s2otw void#;
        };

-- whnfIO
whnfIO1 =
    \r [a1_s2oun eta_s2ouo void_0E]
        case eta_s2ouo of {
          I64# ww1_s2our ->
              let-no-escape {
                $wgo11_s2ous =
                    sat-only \r [ww2_s2out void_0E]
                        case <=# [ww2_s2out 0#] of sat_s2ouv {
                          __DEFAULT ->
                              case tagToEnum# [sat_s2ouv] of {
                                False ->
                                    case seq# [a1_s2oun void#] of {
                                      Unit# _ ->
                                          case -# [ww2_s2out 1#] of sat_s2ouA {
                                            __DEFAULT -> $wgo11_s2ous sat_s2ouA void#;
                                          };
                                    };
                                True -> Unit# [()];
                              };
                        };
              } in  $wgo11_s2ous ww1_s2our void#;
        };

```

The central loops are, I believe, as tight as possible. They check the counter, run the function, update the counter, and loop.

The only one I am unsure about is `whnfIO`. Most of them simplify to just simple `case` statements, but this has maintained the `seq#` primop. This does lead to a slight speed difference with the `case` version, and I'm not sure what the correct method of choosing is.