### PR TITLE
Bump the stack LTS version to 10.5

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,11 +1,10 @@
-resolver: lts-6.31
+resolver: lts-10.5
 
 packages:
 - '.'
 
 extra-deps:
 - microstache-1.0.1.1
-- optparse-applicative-0.13.2.0
 - statistics-0.14.0.0
 
 flags: {}


### PR DESCRIPTION
It defaults to using `optparse-applicative-0.14.0.0`. So the `extra-dep` is not necessary anymore.