### PR TITLE
Decrease impact of gc on benchmark performance (fixes #185)

### DIFF
--- a/Criterion/Measurement.hs
+++ b/Criterion/Measurement.hs
@@ -51,14 +51,17 @@ import Prelude ()
 import Prelude.Compat
 #if MIN_VERSION_base(4,7,0)
 import System.Mem (performGC, performMinorGC)
-#else
+# else
 import System.Mem (performGC)
-foreign import ccall "performGC" performMinorGC :: IO ()
 #endif
 import Text.Printf (printf)
 import qualified Control.Exception as Exc
 import qualified Data.Vector as V
 import qualified GHC.Stats as Stats
+
+#if !(MIN_VERSION_base(4,7,0))
+foreign import ccall "performGC" performMinorGC :: IO ()
+#endif
 
 -- | Statistics about memory usage and the garbage collector. Apart from
 -- 'gcStatsCurrentBytesUsed' and 'gcStatsCurrentBytesSlop' all are cumulative values since

--- a/Criterion/Measurement.hs
+++ b/Criterion/Measurement.hs
@@ -178,11 +178,11 @@ measure :: Benchmarkable        -- ^ Operation to benchmark.
 measure bm iters = runBenchmarkable bm iters addResults $ \ !n act -> do
   -- Ensure the stats from getGCStatistics are up-to-date.
   -- Use performMinorGC if we can to improve performance.
-  #if MIN_VERSION_base(4,7,0)
+#if MIN_VERSION_base(4,7,0)
   performMinorGC
-  #else
+#else
   performGC
-  #endif
+#endif
   startStats <- getGCStatistics
   startTime <- getTime
   startCpuTime <- getCPUTime
@@ -193,11 +193,11 @@ measure bm iters = runBenchmarkable bm iters addResults $ \ !n act -> do
   endCycles <- getCycles
   -- From these we can derive GC-related deltas.
   endStatsPreGC <- getGCStatistics
-  #if MIN_VERSION_base(4,7,0)
+#if MIN_VERSION_base(4,7,0)
   performMinorGC
-  #else
+#else
   performGC
-  #endif
+#endif
   -- From these we can derive all other deltas, and performGC guarantees they
   -- are up-to-date.
   endStatsPostGC <- getGCStatistics

--- a/changelog.md
+++ b/changelog.md
@@ -2,10 +2,10 @@
 
 * We now do three samples for statistics:
 
-  * `performGC` before the first sample, to ensure it's up to date.
-  * Take another sample after the action, without a `performGC`, so we can
-    gather legitimate readings on GC-related statistics.
-  * Then `performGC` and sample once more, so we can get up-to-date
+  * `performMinorGC` before the first sample, to ensure it's up to date.
+  * Take another sample after the action, without a garbage collection, so we
+    can gather legitimate readings on GC-related statistics.
+  * Then `performMinorGC` and sample once more, so we can get up-to-date
     readings on other metrics.
 
   The type of `applyGCStatistics` has changed accordingly. Before, it was:
@@ -27,6 +27,10 @@
 
   When diffing `GCStatistics` in `applyGCStatistics`, we carefully choose
   whether to diff against the end stats pre- or post-GC.
+
+* Use `performMinorGC` rather than `performGC` to update garbage collection
+  statistics. This improves the benchmark performance of fast functions on large
+  objects.
 
 * Fix a bug in the `ToJSON Measured` instance which duplicated the
   mutator CPU seconds where GC CPU seconds should go.


### PR DESCRIPTION
Using the example from issue #185...

Before:
```
benchmarking small-fast
bootstrapping with 39 of 312 samples (12%)
time                 6.877 ns   (6.724 ns .. 7.062 ns)
                     0.996 R²   (0.994 R² .. 0.997 R²)
mean                 6.898 ns   (6.758 ns .. 7.034 ns)
std dev              448.3 ps   (391.7 ps .. 540.9 ps)
variance introduced by outliers: 83% (severely inflated)

benchmarking large-slow
measurement took 69.20 s
bootstrapping with 16 of 289 samples (5%)
time                 6.380 ns   (6.241 ns .. 6.542 ns)
                     0.996 R²   (0.994 R² .. 0.998 R²)
mean                 6.453 ns   (6.267 ns .. 6.668 ns)
std dev              414.9 ps   (320.0 ps .. 548.2 ps)
variance introduced by outliers: 82% (severely inflated)

     354,607,016 bytes allocated in the heap
  74,880,263,968 bytes copied during GC
      64,231,016 bytes maximum residency (2430 sample(s))
         224,872 bytes maximum slop
             134 MB total memory in use (0 MB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0       322 colls,     0 par    0.368s   0.433s     0.0013s    0.0824s
  Gen  1      2430 colls,     0 par   68.188s  68.226s     0.0281s    0.0709s

  INIT    time    0.000s  (  0.000s elapsed)
  MUT     time    6.440s  (  6.450s elapsed)
  GC      time   68.556s  ( 68.659s elapsed)
  EXIT    time    0.004s  (  0.007s elapsed)
  Total   time   75.000s  ( 75.117s elapsed)

  %GC     time      91.4%  (91.4% elapsed)

  Alloc rate    55,063,201 bytes per MUT second

  Productivity   8.6% of total user, 8.6% of total elapsed
```

After:
```
benchmarking small-fast
bootstrapping with 42 of 316 samples (13%)
time                 5.902 ns   (5.888 ns .. 5.924 ns)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 6.015 ns   (5.944 ns .. 6.119 ns)
std dev              281.0 ps   (210.5 ps .. 338.7 ps)
found 9 outliers among 42 samples (21.4%)
  1 (2.4%) high mild
  8 (19.0%) high severe
variance introduced by outliers: 72% (severely inflated)

benchmarking large-slow
bootstrapping with 43 of 316 samples (13%)
time                 5.890 ns   (5.884 ns .. 5.898 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 5.913 ns   (5.893 ns .. 5.990 ns)
std dev              119.0 ps   (16.88 ps .. 251.8 ps)
found 2 outliers among 43 samples (4.7%)
  1 (2.3%) high mild
  1 (2.3%) high severe
variance introduced by outliers: 32% (moderately inflated)

     362,379,952 bytes allocated in the heap
     399,909,824 bytes copied during GC
      64,196,880 bytes maximum residency (14 sample(s))
         236,992 bytes maximum slop
             135 MB total memory in use (0 MB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0      1594 colls,     0 par    0.448s   0.468s     0.0003s    0.0897s
  Gen  1        14 colls,     0 par    0.008s   0.010s     0.0007s    0.0012s

  INIT    time    0.000s  (  0.000s elapsed)
  MUT     time   10.312s  ( 10.330s elapsed)
  GC      time    0.456s  (  0.478s elapsed)
  EXIT    time    0.000s  (  0.006s elapsed)
  Total   time   10.768s  ( 10.814s elapsed)

  %GC     time       4.2%  (4.4% elapsed)

  Alloc rate    35,141,577 bytes per MUT second

  Productivity  95.8% of total user, 95.6% of total elapsed
```

Total time down from 75s -> 10s, 74.5GB -> 0.3GB copied in GC. But most other stats remained quite similar.