### PR TITLE
Call initializeTime before getTime in Measurement.hs; fixes issue #195

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,9 @@
   This will let other libraries, e.g. alternative statistical analysis front-ends
   to import the measurement functionality alone as a lightweight dependency.
 
+* Fixed a macOS-specific bug where using `runAndAnalyse` and other lower-level
+  benchmarking functions would result in an infinite loop.
+
 1.4.1.0
 * Use `base-compat-batteries`.
 

--- a/criterion-measurement/src/Criterion/Measurement.hs
+++ b/criterion-measurement/src/Criterion/Measurement.hs
@@ -188,6 +188,7 @@ measure bm iters = runBenchmarkable bm iters addResults $ \ !n act -> do
   -- the live data in the heap potentially hundreds of times in a
   -- single benchmark.
   performMinorGC
+  initializeTime
   startStats <- getGCStatistics
   startTime <- getTime
   startCpuTime <- getCPUTime
@@ -283,6 +284,7 @@ runBenchmark :: Benchmarkable
              -- meaningful statistical analyses.
              -> IO (V.Vector Measured, Double)
 runBenchmark bm timeLimit = do
+  initializeTime
   runBenchmarkable_ bm 1
   start <- performGC >> getTime
   let loop [] !_ !_ _ = error "unpossible!"

--- a/examples/Overhead.hs
+++ b/examples/Overhead.hs
@@ -11,6 +11,7 @@ import GHC.Stats as GHC
 
 main :: IO ()
 main = do
+  M.initializeTime -- Need to do this before calling M.getTime
   statsEnabled <- getRTSStatsEnabled
   defaultMain $ [
       bench "measure" $            whnfIO (M.measure (whnfIO $ return ()) 1)


### PR DESCRIPTION
My comment before was slightly mistaken. As you said, it's already explicitly stated in the docs that `initializeTime` must be called before using `getTime`.

So the changes I made were just adding `initializeTime` in the appropriate places. Let me know if there's anything I missed.