### PR TITLE
Only incur a dependency on fail on old GHCs.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+next
+
+* Only incur a dependency on `fail` on old GHCs.
+
 1.5.1.0
 
 * Add a `MonadFail Criterion` instance.

--- a/criterion.cabal
+++ b/criterion.cabal
@@ -90,7 +90,6 @@ library
     deepseq >= 1.1.0.0,
     directory,
     exceptions >= 0.8.2 && < 0.11,
-    fail == 4.9.*,
     filepath,
     Glob >= 0.7.2,
     microstache >= 1.0.1 && < 1.1,
@@ -112,6 +111,7 @@ library
       ghc-prim
   if !impl(ghc >= 8.0)
     build-depends:
+      fail == 4.9.*,
       semigroups
 
   default-language: Haskell2010


### PR DESCRIPTION
This should be the last one of these dependency-reduction PRs for a while. Hopefully.