### PR TITLE
Add parserWith to support extensible command-line parsing

### DIFF
--- a/Criterion/Main/Options.hs
+++ b/Criterion/Main/Options.hs
@@ -19,6 +19,7 @@ module Criterion.Main.Options
     , parseWith
     , config
     , describe
+    , describeWith
     , versionInfo
     ) where
 
@@ -194,9 +195,13 @@ regressParams = do
   let ret = (words . map repl . drop 1 $ ps, tidy r)
   either readerError (const (return ret)) $ uncurry validateAccessors ret
 
--- | Flesh out a command line parser.
+-- | Flesh out a command-line parser.
 describe :: Config -> ParserInfo Mode
-describe cfg = info (helper <*> parseWith cfg) $
+describe cfg = describeWith $ parseWith cfg
+
+-- | Flesh out command-line information using a custom 'Parser'.
+describeWith :: Parser a -> ParserInfo a
+describeWith parser = info (helper <*> parser) $
     header ("Microbenchmark suite - " <> versionInfo) <>
     fullDesc <>
     footerDoc (unChunk regressionHelp)

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,13 @@
+next
+
+* Add `parserWith`, which allows creating a `criterion` command-line interface
+  using a custom `optparse-applicative` `Parser`. This is usefule for sitations
+  where one wants to add additional command-line arguments to the default ones
+  that `criterion` provides.
+
+  For an example of how to use `parserWith`, refer to
+  `examples/ExtensibleCLI.hs`.
+
 1.5.3.0
 
 * Make more functions (e.g., `runMode`) able to print the `µ` character on

--- a/examples/ExtensibleCLI.hs
+++ b/examples/ExtensibleCLI.hs
@@ -1,0 +1,38 @@
+module Main where
+
+import Criterion.Main
+import Criterion.Main.Options
+import Options.Applicative
+import Prelude ()
+import Prelude.Compat
+
+data CustomArgs = CustomArgs
+  { -- This data type adds two new arguments, listed below.
+    customArg1    :: Int
+  , customArg2    :: String
+
+    -- The remaining arguments come from criterion itself.
+  , criterionArgs :: Mode
+  }
+
+customParser :: Parser CustomArgs
+customParser = CustomArgs
+  <$> option auto
+      (  long "custom-arg1"
+      <> value 42
+      <> metavar "INT"
+      <> help "Custom argument 1" )
+  <*> strOption
+      (  long "custom-arg2"
+      <> value "Benchmark name"
+      <> metavar "STR"
+      <> help "Custom argument 2" )
+  <*> parseWith defaultConfig
+
+main :: IO ()
+main = do
+  args <- execParser $ describeWith customParser
+  putStrLn $ "custom-arg1: " ++ show (customArg1 args)
+  putStrLn $ "custom-arg2: " ++ customArg2 args
+  runMode (criterionArgs args)
+    [ bench (customArg2 args) $ whnf id $ customArg1 args ]

--- a/examples/criterion-examples.cabal
+++ b/examples/criterion-examples.cabal
@@ -92,6 +92,16 @@ executable good-read-file
     base == 4.*,
     criterion
 
+executable extensible-cli
+  main-is: ExtensibleCLI.hs
+
+  ghc-options: -Wall -rtsopts
+  build-depends:
+    base == 4.*,
+    base-compat-batteries,
+    criterion,
+    optparse-applicative
+
 -- Cannot uncomment due to https://github.com/haskell/cabal/issues/1725
 --
 -- executable judy


### PR DESCRIPTION
While `parser` only accepts a `Config` as an argument, `parserWith` accepts an arbitrary `optparse-applicative` parser. This makes it ideal for using in tandem with custom sets of command-line arguments that extend the default ones the `criterion` provides.

I've added an example of how one can profitably use `parserWith` in `examples/ExtensibleCLI.hs`

Fixes #84.