### PR TITLE
Fix URL for benchmark screenshot

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -5,7 +5,7 @@
 This package provides the Criterion module, a Haskell library for
 measuring and analysing software performance.
 
-<a href="http://www.serpentine.com/criterion/fibber.html" target="_blank"><img src="http://www.serpentine.com/criterion/fibber-screenshot.png"></img></a>
+<a href="http://www.serpentine.com/criterion/fibber.html" target="_blank"><img src="www/fibber-screenshot.png"></a>
 
 To get started, read the <a
 href="http://www.serpentine.com/criterion/tutorial.html"


### PR DESCRIPTION
GitHub proxies all images (see their docs on [anonymized image URLs](https://help.github.com/articles/about-anonymized-image-urls/), and it seems www.serpentine.com isn't sending a Cache-Control: no-cache header for the screenshot and thus it isn't proxied correctly.

Fixed quite simply by using the screenshot in the repo; you can see this working at https://github.com/tchajed/criterion/tree/fix-readme-screenshot.