### PR TITLE
constrain the navigation to make it easier to get useful views.

### DIFF
--- a/templates/default.tpl
+++ b/templates/default.tpl
@@ -317,10 +317,11 @@ $(function () {
     max_time = Math.max(max_time, means[0][i] + stddevs[i]);
   }
   var oq = $("#overview");
+  var max_x = max_time * 1.02;
   o = $.plot(oq, xs, { grid: { borderColor: "#777", hoverable: true },
                        legend: { show: xs.length > 1 },
-                       xaxis: { max: max_time * 1.02 },
-                       yaxis: { ticks: ylabels, tickColor: '#ffffff' },
+                       xaxis: { max: max_x, zoomRange: [false, max_x], panRange: [0, max_x] },
+                       yaxis: { ticks: ylabels, tickColor: '#ffffff', zoomRange: false, panRange: false },
                        zoom: { interactive: true, amount: 1.05 },
                        pan: { interactive: true } });
   if (benches.length > 3)


### PR DESCRIPTION
* zooming all the way out resets to the default view instead of
  continuing to zoom out towards less useful views containing a lot of
  empty space.
* panning all the way to the right resets to the default view in which
  zero is left-aligned instead of continuing to pan and allowing the
  bars to detach from the edge of the graph.
* panning and zooming only affects the x axis, so all the results remain
  in frame.

You can try it for yourself [here](http://gelisam.com/files/criterion-constrained-navigation.html), and compare it with [the current behaviour](http://gelisam.com/files/criterion-unconstrained-navigation.html). Note that the [demo](http://www.serpentine.com/criterion/fibber.html) from the readme uses an older version which doesn't support zooming at all.

Alternatively, here's a picture guide. First, let's look at the default view, which looks the same with or without this PR.

![default-view](https://user-images.githubusercontent.com/49000/52762201-95930500-2fe4-11e9-9bbd-8d2451bb9d37.png)

Looks pretty good! Now let's try to zoom on the fib/1 and fib/5 results. With this PR, it's easy enough: scroll until the zoom is good, then pan all the way to the right so that the zero mark is still visible. (If you're interested, I have [a version](http://gelisam.com/files/criterion-left-constrained-navigation.html) which is careful keep the zero mark in the frame when zooming. The downside is that it's harder to zoom on a portion which does not include the zero mark)

![zoomed-in-with-pr](https://user-images.githubusercontent.com/49000/52762025-cb83b980-2fe3-11e9-81fc-95e22c596221.png)

Without this PR, it's much harder. First, we can't zoom in as much as we want, because the size of the bars grows as well, and the bars disappear if you zoom more than the following:

![zoomed-in-without-pr](https://user-images.githubusercontent.com/49000/52762434-95473980-2fe5-11e9-929a-3c0eddec07cd.png)

In practice, you'll probably get a worse zoom than even that, because if the vertical pan isn't exactly right, the bars disappear as well. This PR eliminates both problems by disabling vertical zooming and vertical panning.

![panned-without-pr](https://user-images.githubusercontent.com/49000/52762465-bd369d00-2fe5-11e9-93fc-eafbf666a81d.png)

After you've looked at the zoomed-in data, you may want to zoom back to the default view, but without this PR, that's trickier than it sounds. It's easy to overshoot, hard to adjust the zoom precisely, and hard to align the zero with the left of the frame:

![not-quite-default-view-without-pr](https://user-images.githubusercontent.com/49000/52762588-4221b680-2fe6-11e9-82f0-8d709b698afa.png)

With this PR, going back to the default view is easy because if you zoom out as much as possible, it caps at the default zoom, and if you pan to the right as much as possible, it caps when the zero is aligned with the left of the frame.