### PR TITLE
Fix #214

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.3.20190425
+# version: 0.3.20190730
 #
 language: c
 dist: xenial
@@ -28,7 +28,7 @@ matrix:
   include:
     - compiler: ghc-8.8.1
       addons: {"apt":{"sources":["hvr-ghc"],"packages":["ghc-8.8.1","cabal-install-3.0"]}}
-      env: GHCHEAD=true
+      env: HEADHACKAGE=true
     - compiler: ghc-8.6.5
       addons: {"apt":{"sources":["hvr-ghc"],"packages":["ghc-8.6.5","cabal-install-2.4"]}}
     - compiler: ghc-8.4.4
@@ -47,7 +47,7 @@ matrix:
       addons: {"apt":{"sources":["hvr-ghc"],"packages":["ghc-7.4.2","cabal-install-2.4"]}}
     - compiler: ghc-head
       addons: {"apt":{"sources":["hvr-ghc"],"packages":["ghc-head","cabal-install-head"]}}
-      env: GHCHEAD=true
+      env: HEADHACKAGE=true
   allow_failures:
     - compiler: ghc-head
     - compiler: ghc-8.8.1
@@ -86,11 +86,12 @@ install:
   - echo "$(${HC} --version) [$(${HC} --print-project-git-commit-id 2> /dev/null || echo '?')]"
   - TEST=--enable-tests
   - BENCH=--enable-benchmarks
-  - GHCHEAD=${GHCHEAD-false}
+  - HEADHACKAGE=${HEADHACKAGE-false}
   - rm -f $CABALHOME/config
   - |
     echo "verbose: normal +nowrap +markoutput"          >> $CABALHOME/config
     echo "remote-build-reporting: anonymous"            >> $CABALHOME/config
+    echo "write-ghc-environment-files: always"          >> $CABALHOME/config
     echo "remote-repo-cache: $CABALHOME/packages"       >> $CABALHOME/config
     echo "logs-dir:          $CABALHOME/logs"           >> $CABALHOME/config
     echo "world-file:        $CABALHOME/world"          >> $CABALHOME/config
@@ -104,15 +105,14 @@ install:
     echo "repository hackage.haskell.org"               >> $CABALHOME/config
     echo "  url: http://hackage.haskell.org/"           >> $CABALHOME/config
   - |
-    if $GHCHEAD; then
+    if $HEADHACKAGE; then
     echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1/g')" >> $CABALHOME/config
-    
-    echo "repository head.hackage"                                                        >> $CABALHOME/config
-    echo "   url: http://head.hackage.haskell.org/"                                       >> $CABALHOME/config
+    echo "repository head.hackage.ghc.haskell.org"                                        >> $CABALHOME/config
+    echo "   url: https://ghc.gitlab.haskell.org/head.hackage/"                           >> $CABALHOME/config
     echo "   secure: True"                                                                >> $CABALHOME/config
-    echo "   root-keys: 07c59cb65787dedfaef5bd5f987ceb5f7e5ebf88b904bbd4c5cbdeb2ff71b740" >> $CABALHOME/config
-    echo "              2e8555dde16ebd8df076f1a8ef13b8f14c66bad8eafefd7d9e37d0ed711821fb" >> $CABALHOME/config
-    echo "              8f79fd2389ab2967354407ec852cbe73f2e8635793ac446d09461ffb99527f6e" >> $CABALHOME/config
+    echo "   root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d" >> $CABALHOME/config
+    echo "              26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329" >> $CABALHOME/config
+    echo "              f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89" >> $CABALHOME/config
     echo "   key-threshold: 3"                                                            >> $CABALHOME/config
     fi
   - cat $CABALHOME/config
@@ -126,17 +126,15 @@ install:
     echo 'packages: "./criterion-measurement"' >> cabal.project
     echo 'packages: "./examples"' >> cabal.project
   - |
-    echo "package criterion"                   >> cabal.project
-    echo "  ghc-options: -Werror"              >> cabal.project
-    echo ""                                    >> cabal.project
-    echo "package criterion-measurement"       >> cabal.project
-    echo "  ghc-options: -Werror"              >> cabal.project
-    echo ""                                    >> cabal.project
-    echo "package criterion-examples"          >> cabal.project
-    echo "  ghc-options: -Werror"              >> cabal.project
-    echo ""                                    >> cabal.project
-    echo "write-ghc-environment-files: always" >> cabal.project
-  - "for pkg in $($HCPKG list --simple-output); do echo $pkg | sed 's/-[^-]*$//' | grep -vE -- '^(criterion|criterion-examples|criterion-measurement)$' | sed 's/^/constraints: /' | sed 's/$/ installed/' >> cabal.project.local; done"
+    echo "package criterion"             >> cabal.project
+    echo "  ghc-options: -Werror"        >> cabal.project
+    echo ""                              >> cabal.project
+    echo "package criterion-measurement" >> cabal.project
+    echo "  ghc-options: -Werror"        >> cabal.project
+    echo ""                              >> cabal.project
+    echo "package criterion-examples"    >> cabal.project
+    echo "  ghc-options: -Werror"        >> cabal.project
+  - "for pkg in $($HCPKG list --simple-output); do echo $pkg | sed 's/-[^-]*$//' | (grep -vE -- '^(criterion|criterion-examples|criterion-measurement)$' || true) | sed 's/^/constraints: /' | sed 's/$/ installed/' >> cabal.project.local; done"
   - cat cabal.project || true
   - cat cabal.project.local || true
   - if [ -f "./configure.ac" ]; then (cd "." && autoreconf -i); fi
@@ -162,17 +160,15 @@ script:
     echo 'packages: "criterion-measurement-*/*.cabal"' >> cabal.project
     echo 'packages: "criterion-examples-*/*.cabal"' >> cabal.project
   - |
-    echo "package criterion"                   >> cabal.project
-    echo "  ghc-options: -Werror"              >> cabal.project
-    echo ""                                    >> cabal.project
-    echo "package criterion-measurement"       >> cabal.project
-    echo "  ghc-options: -Werror"              >> cabal.project
-    echo ""                                    >> cabal.project
-    echo "package criterion-examples"          >> cabal.project
-    echo "  ghc-options: -Werror"              >> cabal.project
-    echo ""                                    >> cabal.project
-    echo "write-ghc-environment-files: always" >> cabal.project
-  - "for pkg in $($HCPKG list --simple-output); do echo $pkg | sed 's/-[^-]*$//' | grep -vE -- '^(criterion|criterion-examples|criterion-measurement)$' | sed 's/^/constraints: /' | sed 's/$/ installed/' >> cabal.project.local; done"
+    echo "package criterion"             >> cabal.project
+    echo "  ghc-options: -Werror"        >> cabal.project
+    echo ""                              >> cabal.project
+    echo "package criterion-measurement" >> cabal.project
+    echo "  ghc-options: -Werror"        >> cabal.project
+    echo ""                              >> cabal.project
+    echo "package criterion-examples"    >> cabal.project
+    echo "  ghc-options: -Werror"        >> cabal.project
+  - "for pkg in $($HCPKG list --simple-output); do echo $pkg | sed 's/-[^-]*$//' | (grep -vE -- '^(criterion|criterion-examples|criterion-measurement)$' || true) | sed 's/^/constraints: /' | sed 's/$/ installed/' >> cabal.project.local; done"
   - cat cabal.project || true
   - cat cabal.project.local || true
   # Building with tests and benchmarks...
@@ -188,6 +184,9 @@ script:
   - ${CABAL} v2-build -w ${HC} --enable-tests --enable-benchmarks --constraint='criterion +embed-data-files' all | color_cabal_output
   - ${CABAL} v2-test -w ${HC} --enable-tests --enable-benchmarks --constraint='criterion +embed-data-files' all | color_cabal_output
   - ${CABAL} v2-haddock -w ${HC} --enable-tests --enable-benchmarks --constraint='criterion +embed-data-files' all | color_cabal_output
+  # Constraint set fast
+  - ${CABAL} v2-build -w ${HC} --enable-tests --disable-benchmarks --constraint='criterion-measurement +fast' --constraint='criterion +fast' all | color_cabal_output
+  - ${CABAL} v2-test -w ${HC} --enable-tests --disable-benchmarks --constraint='criterion-measurement +fast' --constraint='criterion +fast' all | color_cabal_output
 
 # REGENDATA ["--output=.travis.yml","--config=cabal.haskell-ci","cabal.project"]
 # EOF

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -3,6 +3,7 @@ no-tests-no-benchmarks: False
 unconstrained:          False
 local-ghc-options:      -Werror
 cabal-check:            False
+head-hackage:           >=8.8
 
 constraint-set embed-data-files
   constraints: criterion +embed-data-files
@@ -10,3 +11,8 @@ constraint-set embed-data-files
   run-tests:   True
   benchmarks:  True
   haddock:     True
+
+constraint-set fast
+  constraints: criterion-measurement +fast, criterion +fast
+  tests:       True
+  run-tests:   True

--- a/criterion-measurement/changelog.md
+++ b/criterion-measurement/changelog.md
@@ -1,3 +1,11 @@
+next
+
+* Ensure that `Criterion.Measurement.Types.Internal` is always compiled with
+  optimizations, even if the `criterion-measurement` library itself happens to
+  be built with `-O0` or `-fprof-auto`. This is necessary to ensure that the
+  inner benchmarking loop of criterion always finishes in a timely manner,
+  even if the rest of the library is not fully optimized.
+
 0.1.1.0
 
 * Add `nfAppIO` and `whnfAppIO` functions, which take a function and its

--- a/criterion-measurement/src/Criterion/Measurement/Types/Internal.hs
+++ b/criterion-measurement/src/Criterion/Measurement/Types/Internal.hs
@@ -1,5 +1,12 @@
 {-# LANGUAGE BangPatterns #-}
+
+-- Ensure that nf' and whnf' are always optimized, even if
+-- criterion-measurement is compiled with -O0 or -fprof-auto (see #184).
+{-# OPTIONS_GHC -O2 -fno-prof-auto #-}
+-- Make the function applications in nf' and whnf' strict (avoiding allocation)
+-- and avoid floating out the computations.
 {-# OPTIONS_GHC -fno-full-laziness #-}
+
 -- |
 -- Module      : Criterion.Measurement.Types.Internal
 -- Copyright   : (c) 2017 Ryan Scott


### PR DESCRIPTION
If the `nf'`/`whnf'` functions in `Criterion.Measurement.Types.Internal` aren't sufficiently optimized, this can cause `criterion`'s innner benchmarking loop to fail to terminate in certain situations (#214). I hack around this issue by specifically enabling `-O2 -fno-prof-auto` in that module so that even if `criterion-measurement` is compiled with `-O0` or `-fprof-auto`, it won't affect `nf'` or `whnf'`. It's a bit heavy-handed, but it gets the job done.

Along the way, I decided to add a Travis CI configuration for when `criterion` and `criterion-measurement` are compiled with `+fast`, which implies `-O0`. Adding a configuration that builds everything with `-fprof-auto` seems a bit excessive, so I didn't pursue that.

Fixes #214.