### PR TITLE
Criterion-measurements with even less dependencies

### DIFF
--- a/Criterion/Internal.hs
+++ b/Criterion/Internal.hs
@@ -51,7 +51,7 @@ runOne i desc bm = do
   (meas,timeTaken) <- liftIO $ runBenchmark bm timeLimit
   when (timeTaken > timeLimit * 1.25) .
     void $ prolix "measurement took %s\n" (secs timeTaken)
-  return (Measurement i desc meas)
+  return (Measurement i desc (V.fromList meas))
 
 -- | Analyse a single benchmark.
 analyseOne :: Int -> String -> V.Vector Measured -> Criterion DataRecord

--- a/Criterion/Report.hs
+++ b/Criterion/Report.hs
@@ -216,9 +216,10 @@ formatReport reports templateName = do
         [KDE{..}]          = reportKDEs
         SampleAnalysis{..} = reportAnalysis
 
-        iters  = measure measIters reportMeasured
-        times  = measure measTime reportMeasured
-        cycles = measure measCycles reportMeasured
+        rmeas  = G.toList reportMeasured
+        iters  = U.fromList $ measure measIters  rmeas
+        times  = U.fromList $ measure measTime   rmeas
+        cycles = U.fromList $ measure measCycles rmeas
         anMeanConfidenceLevel
                = confidenceLevel $ confIntCL $ estError anMean
         (anMeanLowerBound, anMeanUpperBound)

--- a/Criterion/Types.hs
+++ b/Criterion/Types.hs
@@ -146,6 +146,26 @@ data Outliers = Outliers {
 instance FromJSON Outliers
 instance ToJSON Outliers
 
+instance FromJSON Measured where
+    parseJSON v = do
+      (a,b,c,d,e,f,g,h,i,j,k) <- parseJSON v
+      -- The first four fields are not subject to the encoding policy:
+      return $ Measured a b c d
+                       (int e) (int f) (int g)
+                       (db h) (db i) (db j) (db k)
+      where int = toInt; db = toDouble
+
+-- Here we treat the numeric fields as `Maybe Int64` and `Maybe Double`
+-- and we use a specific policy for deciding when they should be Nothing,
+-- which becomes null in JSON.
+instance ToJSON Measured where
+    toJSON Measured{..} = toJSON
+      (measTime, measCpuTime, measCycles, measIters,
+       i measAllocated, i measNumGcs, i measBytesCopied,
+       d measMutatorWallSeconds, d measMutatorCpuSeconds,
+       d measGcWallSeconds, d measGcCpuSeconds)
+      where i = fromInt; d = fromDouble
+
 instance Binary Outliers where
     put (Outliers v w x y z) = put v >> put w >> put x >> put y >> put z
     get = Outliers <$> get <*> get <*> get <*> get <*> get

--- a/criterion-measurement/criterion-measurement.cabal
+++ b/criterion-measurement/criterion-measurement.cabal
@@ -33,13 +33,11 @@ library
   exposed-modules:     Criterion.Measurement
                        Criterion.Measurement.Types
                        Criterion.Measurement.Types.Internal
-  build-depends:       aeson >= 0.8
-                     , base >= 4.5 && < 5
+  build-depends:       base >= 4.5 && < 5
                      , base-compat >= 0.9
                      , binary >= 0.5.1.0
                      , containers
                      , deepseq >= 1.1.0.0
-                     , vector >= 0.7.1
   if impl(ghc < 7.6)
     build-depends:
       ghc-prim

--- a/criterion-measurement/src/Criterion/Measurement.hs
+++ b/criterion-measurement/src/Criterion/Measurement.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE Trustworthy #-}
+{-# LANGUAGE Safe #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE BangPatterns, CPP, ForeignFunctionInterface,
     ScopedTypeVariables #-}
@@ -56,7 +56,6 @@ import System.Mem (performGC)
 #endif
 import Text.Printf (printf)
 import qualified Control.Exception as Exc
-import qualified Data.Vector as V
 import qualified GHC.Stats as Stats
 
 #if !(MIN_VERSION_base(4,7,0))
@@ -288,7 +287,7 @@ runBenchmark :: Benchmarkable
              -- should take.  In practice, this time limit may be
              -- exceeded in order to generate enough data to perform
              -- meaningful statistical analyses.
-             -> IO (V.Vector Measured, Double)
+             -> IO ([Measured], Double)
 runBenchmark bm timeLimit = do
   initializeTime
   runBenchmarkable_ bm 1
@@ -310,7 +309,7 @@ runBenchmark bm timeLimit = do
            overThresh > threshold * 10 &&
            count >= (4 :: Int)
           then do
-            let !v = V.reverse (V.fromList acc)
+            let !v = reverse acc
             return (v, endTime - start)
           else loop niters overThresh (count+1) (m:acc)
   loop (squish (unfoldr series 1)) 0 0 []

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-10.5
+resolver: lts-14.0
 
 packages:
 - '.'


### PR DESCRIPTION
Remove dependencies on `vector` and `aeson`. Allows `criterion-measurements` to be used only with boot libraries (and `base-compat`)