### PR TITLE
Make tutorial compatible with NegativeLiterals

### DIFF
--- a/www/tutorial.md
+++ b/www/tutorial.md
@@ -31,7 +31,7 @@ fib m | m < 0     = error "negative!"
   where
     go 0 = 0
     go 1 = 1
-    go n = go (n-1) + go (n-2)
+    go n = go (n - 1) + go (n - 2)
 
 -- Our benchmark harness.
 main = defaultMain [


### PR DESCRIPTION
I pasted the tutorial into a project to get started with criterion and got this confusing error message:

```
test.hs:9:5: error:
    • Occurs check: cannot construct the infinite type:
        t1 ~ Integer -> t1
      Expected type: t1 -> p1
        Actual type: (Integer -> t1) -> p1
    • In an equation for ‘fib’:
          fib m
            | m < 0 = error "negative!"
            | otherwise = go m
            where
                go 0 = 0
                go 1 = 1
                go n = go (n -1) + go (n -2)
    • Relevant bindings include go :: t1 -> p1 (bound at test.hs:9:5)
```

Which occurs when NegativeLiterals is enabled. An easy fix is to add spaces around the `-`. 

Also, I at least personally think that this looks a little better, and matches the style of `m < 0` vs `m<0` earlier in the exampl ecode.