### PR TITLE
Warn if report names contains newlines

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+next
+
+* Warn if an HTML report name contains newlines, and replace newlines with
+  whitespace to avoid syntax errors in the report itself.
+
 1.5.6.2
 
 * Use unescaped HTML in the `json.tpl` template.


### PR DESCRIPTION
Newlines wreak havoc on JavaScript strings in the default HTML report. We could attempt to turn newlines into properly escaped JS strings before compiling the Mustache template, but this is overkill, since the string will be rendered as if the newlines were simple spaces anyway. As a result, we simply turn all newlines into spaces and emit a warning.

Fixes #224.