### PR TITLE
Escape JSON to avoid parsing the content as HTML

### DIFF
--- a/templates/criterion.js
+++ b/templates/criterion.js
@@ -843,8 +843,8 @@
     ]);
   }
   document.addEventListener('DOMContentLoaded', function() {
-    var reportData = JSON.parse(document.getElementById('report-data')
-      .getAttribute('data-report-json'))
+    var rawJSON = document.getElementById('report-data').text;
+    var reportData = JSON.parse(rawJSON)
       .map(function(report) {
         report.groups = report.reportName.split('/');
         return report;

--- a/templates/default.tpl
+++ b/templates/default.tpl
@@ -10,6 +10,9 @@
   <style>
     {{{criterion-css}}}
   </style>
+  <script type="application/json" id="report-data">
+    {{{json}}}
+  </script>
   <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
 <body>
@@ -32,8 +35,6 @@
     </div>
     <aside id="overview-chart"></aside>
     <main id="reports"></main>
-
-    <div id="report-data" data-report-json='{{{json}}}'></div>
   </div>
 
   <aside id="controls-explanation" class="explanation no-print">


### PR DESCRIPTION
By crafting a malicious string it was quite easy to escape the HTML
attribute that contained the JSON report data allowing injection of
arbitrary HTML using the report names.

This commit aims to mitigate the breakage of the reports when report names
contain unexpected characters. The JSON data is moved to a <script> tag and
the content is escaped by replacing significant HTML characters with their
corresponding JSON escape sequences. The '<' character is replaced with the
sequence "\u003c", '&' is replaced with "\u0026" and so on.

![screenshot-2020-11-16T23:03:20+09:00](https://user-images.githubusercontent.com/217918/99261390-032a3000-2860-11eb-9216-88d55b0f470f.png)

The processing of `/` is still not ideal, if a report name contains that character
then it is treated as a group separator.