### PR TITLE
Fix typos

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -102,7 +102,7 @@ next
 1.5.4.0
 
 * Add `parserWith`, which allows creating a `criterion` command-line interface
-  using a custom `optparse-applicative` `Parser`. This is usefule for sitations
+  using a custom `optparse-applicative` `Parser`. This is useful for situations
   where one wants to add additional command-line arguments to the default ones
   that `criterion` provides.
 
@@ -283,7 +283,7 @@ next
 1.2.1.0
 
 * Add `GCStatistics`, `getGCStatistics`, and `applyGCStatistics` to
-  `Criterion.Measurement`. These are inteded to replace `GCStats` (which has
+  `Criterion.Measurement`. These are intended to replace `GCStats` (which has
   been deprecated in `base` and will be removed in GHC 8.4), as well as
   `getGCStats` and `applyGCStats`, which have also been deprecated and will be
   removed in the next major `criterion` release.
@@ -339,7 +339,7 @@ next
 
 * Restore support for 32-bit Intel CPUs.
 
-* Restore build compatibilty with GHC 7.4.
+* Restore build compatibility with GHC 7.4.
 
 1.1.1.0
 

--- a/criterion-measurement/src/Criterion/Measurement/Types.hs
+++ b/criterion-measurement/src/Criterion/Measurement/Types.hs
@@ -503,7 +503,7 @@ envWithCleanup = Environment
 -- The environment is evaluated to normal form before the benchmark is run.
 --
 -- When using 'whnf', 'whnfIO', etc. Criterion creates a 'Benchmarkable'
--- whichs runs a batch of @N@ repeat runs of that expressions. Criterion may
+-- which's runs a batch of @N@ repeat runs of that expressions. Criterion may
 -- run any number of these batches to get accurate measurements. Environments
 -- created by 'env' and 'envWithCleanup', are shared across all these batches
 -- of runs.

--- a/criterion-measurement/src/Criterion/Measurement/Types.hs
+++ b/criterion-measurement/src/Criterion/Measurement/Types.hs
@@ -503,7 +503,7 @@ envWithCleanup = Environment
 -- The environment is evaluated to normal form before the benchmark is run.
 --
 -- When using 'whnf', 'whnfIO', etc. Criterion creates a 'Benchmarkable'
--- which's runs a batch of @N@ repeat runs of that expressions. Criterion may
+-- which runs a batch of @N@ repeat runs of that expressions. Criterion may
 -- run any number of these batches to get accurate measurements. Environments
 -- created by 'env' and 'envWithCleanup', are shared across all these batches
 -- of runs.

--- a/criterion-measurement/src/Criterion/Measurement/Types/Internal.hs
+++ b/criterion-measurement/src/Criterion/Measurement/Types/Internal.hs
@@ -32,7 +32,7 @@ import GHC.Types (SPEC(..))
 -- from environments when no concrete environment is available.
 fakeEnvironment :: env
 fakeEnvironment = error $ unlines
-  [ "Criterion atttempted to retrieve a non-existent environment!"
+  [ "Criterion attempted to retrieve a non-existent environment!"
   , "\tPerhaps you forgot to use lazy pattern matching in a function which"
   , "\tconstructs benchmarks from an environment?"
   , "\t(see the documentation for `env` for details)"


### PR DESCRIPTION
Found via `codespell -L te,ot,ue`